### PR TITLE
feat: exact phrase match bonus for multi-word lexical queries

### DIFF
--- a/internal/engine/benchmark_study_test.go
+++ b/internal/engine/benchmark_study_test.go
@@ -239,6 +239,8 @@ func studyCases() []studyCase {
 		// Page 5: Dashboard — 2 queries
 		{"Analytics Dashboard", "export report", "e1", dashboard},
 		{"Analytics Dashboard", "date range selector", "e3", dashboard},
+		// Phrase-sensitive: prefer exact phrase over token-only overlap.
+		{"Analytics Dashboard", "add widget", "e2", dashboard},
 
 		// Page 6: Search Results — 2 queries
 		{"Search Results", "search input", "e0", search},
@@ -259,6 +261,9 @@ func studyCases() []studyCase {
 		// Page 10: Checkout — 2 queries
 		{"Checkout Page", "place order button", "e11", checkout},
 		{"Checkout Page", "card number field", "e7", checkout},
+
+		// Phrase-sensitive: keep multi-word intent intact.
+		{"Product Page", "add to cart button", "e4", product},
 	}
 }
 

--- a/internal/engine/lexical.go
+++ b/internal/engine/lexical.go
@@ -17,6 +17,10 @@ const (
 	synonymBoostWeight = 0.30
 	// prefixMatchWeight controls how much prefix matches contribute.
 	prefixMatchWeight = 0.20
+	// phraseExactBonus rewards full multi-word phrase containment.
+	phraseExactBonus = 0.15
+	// phrasePartialBonus rewards partial phrase containment (bigrams/trigrams).
+	phrasePartialBonus = 0.08
 )
 
 // LexicalMatcher scores elements using Jaccard similarity with synonym
@@ -197,11 +201,45 @@ func LexicalScore(query, desc string) float64 {
 		roleBoost = roleBoostCap
 	}
 
-	score := jaccard + synScore + prefixScore + roleBoost
+	// --- 5. Phrase bonus for preserving multi-word intent ---
+	phraseBoost := phraseBonus(qTokens, dTokens)
+
+	score := jaccard + synScore + prefixScore + roleBoost + phraseBoost
 	if score > 1.0 {
 		score = 1.0
 	}
 	return score
+}
+
+func phraseBonus(qTokens, dTokens []string) float64 {
+	if len(qTokens) < 2 || len(dTokens) < 2 {
+		return 0
+	}
+
+	qPhrase := strings.Join(qTokens, " ")
+	dPhrase := strings.Join(dTokens, " ")
+	if strings.Contains(dPhrase, qPhrase) {
+		return phraseExactBonus
+	}
+
+	// Fallback: reward any matching significant query sub-phrase.
+	for n := minInt(3, len(qTokens)); n >= 2; n-- {
+		for i := 0; i+n <= len(qTokens); i++ {
+			sub := strings.Join(qTokens[i:i+n], " ")
+			if strings.Contains(dPhrase, sub) {
+				return phrasePartialBonus
+			}
+		}
+	}
+
+	return 0
+}
+
+func minInt(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
 }
 
 func tokenPrefixScore(qTokens, dTokens []string) float64 {

--- a/internal/engine/lexical_test.go
+++ b/internal/engine/lexical_test.go
@@ -244,6 +244,29 @@ func TestLexicalScore_StopwordRemoval(t *testing.T) {
 	}
 }
 
+func TestLexicalScore_PhraseBonus_ExactPhraseBeatsPartial(t *testing.T) {
+	exact := LexicalScore("add to cart", "button: Add to cart")
+	partial := LexicalScore("add to cart", "button: Add")
+	if exact <= partial {
+		t.Errorf("expected exact phrase match to score higher, exact=%f partial=%f", exact, partial)
+	}
+}
+
+func TestLexicalScore_PhraseBonus_PartialSubPhrase(t *testing.T) {
+	withPartial := LexicalScore("create account now", "button: Create account")
+	withoutPartial := LexicalScore("create account now", "button: Register")
+	if withPartial <= withoutPartial {
+		t.Errorf("expected partial phrase match to score higher, withPartial=%f withoutPartial=%f", withPartial, withoutPartial)
+	}
+}
+
+func TestLexicalScore_PhraseBonus_NoPhraseMatch(t *testing.T) {
+	nonMatch := LexicalScore("security settings", "button: Export report")
+	if nonMatch > 0.35 {
+		t.Errorf("expected low score when no phrase exists, got %f", nonMatch)
+	}
+}
+
 // LexicalMatcher (types.ElementMatcher interface) tests
 
 // LexicalMatcher (types.ElementMatcher interface) tests


### PR DESCRIPTION
## Summary
- add phrase bonus support to LexicalScore for multi-word queries
- prefer exact full-phrase matches, with a bounded partial phrase fallback
- add unit tests for exact phrase, partial phrase, and no phrase scenarios
- add phrase-sensitive cases to benchmark study coverage

## Issue
Closes #1

## Validation
- go test -c ./internal/engine (compile-only)
- Full test execution is blocked in this environment by Windows Application Control policy for generated test executables
