### PR TITLE
feat: add structural context (parent/section) to descriptors

### DIFF
--- a/cmd/semantic/main.go
+++ b/cmd/semantic/main.go
@@ -67,6 +67,8 @@ type snapshotElement struct {
 	Name        string `json:"name"`
 	Value       string `json:"value"`
 	Interactive bool   `json:"interactive"`
+	Parent      string `json:"parent"`
+	Section     string `json:"section"`
 }
 
 func loadSnapshot(path string) ([]semantic.ElementDescriptor, error) {
@@ -100,6 +102,8 @@ func loadSnapshot(path string) ([]semantic.ElementDescriptor, error) {
 			Name:        e.Name,
 			Value:       e.Value,
 			Interactive: e.Interactive,
+			Parent:      e.Parent,
+			Section:     e.Section,
 		}
 	}
 	return descs, nil

--- a/cmd/semantic/main_test.go
+++ b/cmd/semantic/main_test.go
@@ -12,8 +12,8 @@ func TestLoadSnapshot_PropagatesInteractiveFlag(t *testing.T) {
 	}
 
 	json := `[
-		{"ref":"e1","role":"button","name":"Submit","interactive":true},
-		{"ref":"e2","role":"text","name":"Submit","interactive":false}
+		{"ref":"e1","role":"button","name":"Submit","interactive":true,"parent":"Login form","section":"Authentication"},
+		{"ref":"e2","role":"text","name":"Submit","interactive":false,"parent":"Payment form","section":"Checkout"}
 	]`
 	if _, err := f.WriteString(json); err != nil {
 		t.Fatalf("WriteString failed: %v", err)
@@ -32,7 +32,19 @@ func TestLoadSnapshot_PropagatesInteractiveFlag(t *testing.T) {
 	if !descs[0].Interactive {
 		t.Fatalf("expected first descriptor interactive=true")
 	}
+	if descs[0].Parent != "Login form" {
+		t.Fatalf("expected first descriptor parent=Login form, got %q", descs[0].Parent)
+	}
+	if descs[0].Section != "Authentication" {
+		t.Fatalf("expected first descriptor section=Authentication, got %q", descs[0].Section)
+	}
 	if descs[1].Interactive {
 		t.Fatalf("expected second descriptor interactive=false")
+	}
+	if descs[1].Parent != "Payment form" {
+		t.Fatalf("expected second descriptor parent=Payment form, got %q", descs[1].Parent)
+	}
+	if descs[1].Section != "Checkout" {
+		t.Fatalf("expected second descriptor section=Checkout, got %q", descs[1].Section)
 	}
 }

--- a/internal/engine/lexical_test.go
+++ b/internal/engine/lexical_test.go
@@ -311,6 +311,32 @@ func TestLexicalMatcher_ActionQueryPrefersInteractiveElement(t *testing.T) {
 	}
 }
 
+func TestLexicalMatcher_SectionContextDisambiguatesSubmitButtons(t *testing.T) {
+	m := NewLexicalMatcher()
+
+	elements := []types.ElementDescriptor{
+		{Ref: "login-submit", Role: "button", Name: "Submit", Parent: "Login form", Section: "Login form"},
+		{Ref: "payment-submit", Role: "button", Name: "Submit", Parent: "Payment form", Section: "Payment form"},
+	}
+
+	result, err := m.Find(context.Background(), "submit button in login", elements, types.FindOptions{
+		Threshold: 0,
+		TopK:      2,
+	})
+	if err != nil {
+		t.Fatalf("Find returned error: %v", err)
+	}
+	if len(result.Matches) < 2 {
+		t.Fatalf("expected 2 matches, got %d", len(result.Matches))
+	}
+	if result.BestRef != "login-submit" {
+		t.Fatalf("expected login submit to rank first, got %s", result.BestRef)
+	}
+	if result.Matches[0].Score <= result.Matches[1].Score {
+		t.Fatalf("expected login submit score > payment submit score, got %f <= %f", result.Matches[0].Score, result.Matches[1].Score)
+	}
+}
+
 func TestElementFrequency_IEF_RareTokenHigherThanCommon(t *testing.T) {
 	elements := []types.ElementDescriptor{
 		{Ref: "e1", Role: "button", Name: "Checkout"},

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -83,6 +83,8 @@ type ElementDescriptor struct {
 	Name        string
 	Value       string
 	Interactive bool
+	Parent      string
+	Section     string
 }
 
 // Composite returns a single string combining role, name, and value
@@ -98,6 +100,9 @@ func (ed *ElementDescriptor) Composite() string {
 	}
 	if ed.Value != "" && ed.Value != ed.Name {
 		parts = append(parts, "["+ed.Value+"]")
+	}
+	if ed.Section != "" {
+		parts = append(parts, "{"+ed.Section+"}")
 	}
 
 	return strings.Join(parts, " ")

--- a/semantic_test.go
+++ b/semantic_test.go
@@ -79,3 +79,10 @@ func TestElementDescriptor_Composite(t *testing.T) {
 		t.Errorf("unexpected composite: %q", d.Composite())
 	}
 }
+
+func TestElementDescriptor_Composite_IncludesSection(t *testing.T) {
+	d := semantic.ElementDescriptor{Role: "button", Name: "Submit", Section: "Login form"}
+	if d.Composite() != "button: Submit {Login form}" {
+		t.Errorf("unexpected composite with section: %q", d.Composite())
+	}
+}


### PR DESCRIPTION
## Summary
- extend `ElementDescriptor` with `Parent` and `Section` fields for structural context
- include `Section` in `Composite()` searchable text as `{Section}` to disambiguate similar controls across page areas
- propagate `parent` and `section` fields from CLI snapshot JSON into descriptors in `loadSnapshot()`
- add tests for:
  - section inclusion in composite string
  - snapshot propagation for parent/section fields
  - disambiguation behavior: `submit button in login` prefers login submit over payment submit

## Issue
Closes #4

## Validation
- `go test -c ./internal/engine`
- `go test -c ./cmd/semantic`
- `go test -c .`
- `go test ./internal/engine -run SectionContext -count=1 -v`
- `go test ./cmd/semantic -run LoadSnapshot -count=1 -v`
- `go test . -run Composite -count=1 -v`
