### PR TITLE
feat: add weighted Jaccard helper for snapshot-aware lexical scoring

### DIFF
--- a/internal/engine/lexical.go
+++ b/internal/engine/lexical.go
@@ -344,6 +344,43 @@ func tokenWeight(token string, ef *ElementFrequency) float64 {
 	return w
 }
 
+// weightedJaccard computes set-based Jaccard similarity with optional
+// per-token weights (e.g., IDF). Missing or non-positive token weights default
+// to 1.0 so callers can pass partial maps safely.
+func weightedJaccard(qTokens, dTokens []string, idf map[string]float64) float64 {
+	qSet := tokenSet(qTokens)
+	dSet := tokenSet(dTokens)
+
+	all := make(map[string]bool, len(qSet)+len(dSet))
+	for t := range qSet {
+		all[t] = true
+	}
+	for t := range dSet {
+		all[t] = true
+	}
+
+	var intersectW float64
+	var unionW float64
+	for t := range all {
+		w := 1.0
+		if idf != nil {
+			if iw, ok := idf[t]; ok && iw > 0 {
+				w = iw
+			}
+		}
+
+		if qSet[t] && dSet[t] {
+			intersectW += w
+		}
+		unionW += w
+	}
+
+	if unionW == 0 {
+		return 0
+	}
+	return intersectW / unionW
+}
+
 func tokenPrefixScore(qTokens, dTokens []string) float64 {
 	if len(qTokens) == 0 {
 		return 0

--- a/internal/engine/lexical_test.go
+++ b/internal/engine/lexical_test.go
@@ -328,6 +328,55 @@ func TestElementFrequency_IEF_RareTokenHigherThanCommon(t *testing.T) {
 	}
 }
 
+func TestWeightedJaccard_NilIDFMatchesUnitWeights(t *testing.T) {
+	q := []string{"status", "order", "1049"}
+	d := []string{"status", "order", "1001"}
+
+	withNil := weightedJaccard(q, d, nil)
+	withUnit := weightedJaccard(q, d, map[string]float64{
+		"status": 1,
+		"order":  1,
+		"1049":   1,
+		"1001":   1,
+	})
+
+	if math.Abs(withNil-withUnit) > 1e-9 {
+		t.Fatalf("expected nil IDF to match unit-weight Jaccard, nil=%f unit=%f", withNil, withUnit)
+	}
+}
+
+func TestLexicalScoreWithFrequency_50RowTableImprovesIdentifierSeparation(t *testing.T) {
+	elements := make([]types.ElementDescriptor, 0, 50)
+	for i := 1000; i < 1050; i++ {
+		elements = append(elements, types.ElementDescriptor{
+			Ref:  "row-" + strconv.Itoa(i),
+			Role: "row",
+			Name: "Order " + strconv.Itoa(i) + " status price name",
+		})
+	}
+
+	ef := BuildElementFrequency(elements)
+	if ef == nil {
+		t.Fatalf("expected non-nil ElementFrequency")
+	}
+
+	query := "order 1049 status price"
+	targetComposite := elements[49].Composite() // row-1049
+	distractorComposite := elements[0].Composite()
+
+	targetUnweighted := lexicalScore(query, targetComposite, false, nil)
+	distractorUnweighted := lexicalScore(query, distractorComposite, false, nil)
+	targetWeighted := lexicalScore(query, targetComposite, false, ef)
+	distractorWeighted := lexicalScore(query, distractorComposite, false, ef)
+
+	unweightedMargin := targetUnweighted - distractorUnweighted
+	weightedMargin := targetWeighted - distractorWeighted
+
+	if weightedMargin <= unweightedMargin {
+		t.Fatalf("expected weighted scoring to improve unique identifier separation, unweightedMargin=%f weightedMargin=%f", unweightedMargin, weightedMargin)
+	}
+}
+
 func TestLexicalScoreWithFrequency_NilMatchesDefault(t *testing.T) {
 	base := LexicalScore("checkout button", "button: Checkout")
 	weightedNil := LexicalScoreWithFrequency("checkout button", "button: Checkout", nil)


### PR DESCRIPTION
## Summary
- add `weightedJaccard(qTokens, dTokens, idf)` helper for set-based weighted overlap scoring
- keep current lexical behavior backward compatible when weights are not provided (defaults remain unchanged)
- add unit test proving nil IDF behaves the same as unit-weight Jaccard
- add 50-row table test showing frequency weighting increases separation for unique identifiers vs common headers

## Issue
Closes #5

## Validation
- `go test ./internal/engine -run "WeightedJaccard|50RowTable|NilMatchesDefault|CheckoutButtonDiscrimination" -count=1 -v`
- `go test -c ./internal/engine`
