### PR TITLE
feat(recovery): adaptive confidence thresholds from history

### DIFF
--- a/internal/engine/lexical.go
+++ b/internal/engine/lexical.go
@@ -344,6 +344,43 @@ func tokenWeight(token string, ef *ElementFrequency) float64 {
 	return w
 }
 
+// weightedJaccard computes set-based Jaccard similarity with optional
+// per-token weights (e.g., IDF). Missing or non-positive token weights default
+// to 1.0 so callers can pass partial maps safely.
+func weightedJaccard(qTokens, dTokens []string, idf map[string]float64) float64 {
+	qSet := tokenSet(qTokens)
+	dSet := tokenSet(dTokens)
+
+	all := make(map[string]bool, len(qSet)+len(dSet))
+	for t := range qSet {
+		all[t] = true
+	}
+	for t := range dSet {
+		all[t] = true
+	}
+
+	var intersectW float64
+	var unionW float64
+	for t := range all {
+		w := 1.0
+		if idf != nil {
+			if iw, ok := idf[t]; ok && iw > 0 {
+				w = iw
+			}
+		}
+
+		if qSet[t] && dSet[t] {
+			intersectW += w
+		}
+		unionW += w
+	}
+
+	if unionW == 0 {
+		return 0
+	}
+	return intersectW / unionW
+}
+
 func tokenPrefixScore(qTokens, dTokens []string) float64 {
 	if len(qTokens) == 0 {
 		return 0

--- a/internal/engine/lexical_test.go
+++ b/internal/engine/lexical_test.go
@@ -328,6 +328,55 @@ func TestElementFrequency_IEF_RareTokenHigherThanCommon(t *testing.T) {
 	}
 }
 
+func TestWeightedJaccard_NilIDFMatchesUnitWeights(t *testing.T) {
+	q := []string{"status", "order", "1049"}
+	d := []string{"status", "order", "1001"}
+
+	withNil := weightedJaccard(q, d, nil)
+	withUnit := weightedJaccard(q, d, map[string]float64{
+		"status": 1,
+		"order":  1,
+		"1049":   1,
+		"1001":   1,
+	})
+
+	if math.Abs(withNil-withUnit) > 1e-9 {
+		t.Fatalf("expected nil IDF to match unit-weight Jaccard, nil=%f unit=%f", withNil, withUnit)
+	}
+}
+
+func TestLexicalScoreWithFrequency_50RowTableImprovesIdentifierSeparation(t *testing.T) {
+	elements := make([]types.ElementDescriptor, 0, 50)
+	for i := 1000; i < 1050; i++ {
+		elements = append(elements, types.ElementDescriptor{
+			Ref:  "row-" + strconv.Itoa(i),
+			Role: "row",
+			Name: "Order " + strconv.Itoa(i) + " status price name",
+		})
+	}
+
+	ef := BuildElementFrequency(elements)
+	if ef == nil {
+		t.Fatalf("expected non-nil ElementFrequency")
+	}
+
+	query := "order 1049 status price"
+	targetComposite := elements[49].Composite() // row-1049
+	distractorComposite := elements[0].Composite()
+
+	targetUnweighted := lexicalScore(query, targetComposite, false, nil)
+	distractorUnweighted := lexicalScore(query, distractorComposite, false, nil)
+	targetWeighted := lexicalScore(query, targetComposite, false, ef)
+	distractorWeighted := lexicalScore(query, distractorComposite, false, ef)
+
+	unweightedMargin := targetUnweighted - distractorUnweighted
+	weightedMargin := targetWeighted - distractorWeighted
+
+	if weightedMargin <= unweightedMargin {
+		t.Fatalf("expected weighted scoring to improve unique identifier separation, unweightedMargin=%f weightedMargin=%f", unweightedMargin, weightedMargin)
+	}
+}
+
 func TestLexicalScoreWithFrequency_NilMatchesDefault(t *testing.T) {
 	base := LexicalScore("checkout button", "button: Checkout")
 	weightedNil := LexicalScoreWithFrequency("checkout button", "button: Checkout", nil)

--- a/recovery/confidence_tracker.go
+++ b/recovery/confidence_tracker.go
@@ -1,0 +1,153 @@
+package recovery
+
+import "sync"
+
+const (
+	defaultAdaptiveFallback = 0.4
+)
+
+// ConfidenceStats exposes adaptive-threshold diagnostics.
+type ConfidenceStats struct {
+	SuccessCount     int     `json:"success_count"`
+	FailureCount     int     `json:"failure_count"`
+	MeanSuccess      float64 `json:"mean_success"`
+	MeanFailure      float64 `json:"mean_failure"`
+	CurrentThreshold float64 `json:"current_threshold"`
+	MinSamples       int     `json:"min_samples"`
+	MaxSamples       int     `json:"max_samples"`
+	Adaptive         bool    `json:"adaptive"`
+}
+
+// ConfidenceTracker tracks recovery outcomes and computes an adaptive threshold.
+type ConfidenceTracker struct {
+	mu         sync.Mutex
+	successes  []float64
+	failures   []float64
+	maxSamples int
+	minSamples int
+}
+
+// NewConfidenceTracker creates a tracker with bounded per-class sample buffers.
+func NewConfidenceTracker(maxSamples, minSamples int) *ConfidenceTracker {
+	if maxSamples <= 0 {
+		maxSamples = 200
+	}
+	if minSamples <= 0 {
+		minSamples = 20
+	}
+	return &ConfidenceTracker{
+		maxSamples: maxSamples,
+		minSamples: minSamples,
+	}
+}
+
+// Record stores one recovery score outcome.
+func (ct *ConfidenceTracker) Record(score float64, succeeded bool) {
+	if ct == nil {
+		return
+	}
+	if score < 0 {
+		score = 0
+	}
+	if score > 1 {
+		score = 1
+	}
+
+	ct.mu.Lock()
+	defer ct.mu.Unlock()
+
+	if succeeded {
+		ct.successes = appendWithRing(ct.successes, score, ct.maxSamples)
+		return
+	}
+	ct.failures = appendWithRing(ct.failures, score, ct.maxSamples)
+}
+
+// OptimalThreshold returns the adaptive threshold with a fixed fallback.
+func (ct *ConfidenceTracker) OptimalThreshold() float64 {
+	return ct.OptimalThresholdWithDefault(defaultAdaptiveFallback)
+}
+
+// OptimalThresholdWithDefault returns the adaptive threshold if there are enough
+// success and failure samples; otherwise it returns defaultThreshold.
+func (ct *ConfidenceTracker) OptimalThresholdWithDefault(defaultThreshold float64) float64 {
+	if ct == nil {
+		return defaultThreshold
+	}
+
+	ct.mu.Lock()
+	defer ct.mu.Unlock()
+
+	if len(ct.successes) < ct.minSamples || len(ct.failures) < ct.minSamples {
+		return defaultThreshold
+	}
+
+	meanSuccess := mean(ct.successes)
+	meanFailure := mean(ct.failures)
+	threshold := (meanSuccess + meanFailure) / 2.0
+	if threshold < 0 {
+		return 0
+	}
+	if threshold > 1 {
+		return 1
+	}
+	return threshold
+}
+
+// Stats returns tracker state for diagnostics.
+func (ct *ConfidenceTracker) Stats(defaultThreshold float64) ConfidenceStats {
+	if ct == nil {
+		return ConfidenceStats{CurrentThreshold: defaultThreshold}
+	}
+
+	ct.mu.Lock()
+	defer ct.mu.Unlock()
+
+	stats := ConfidenceStats{
+		SuccessCount: len(ct.successes),
+		FailureCount: len(ct.failures),
+		MinSamples:   ct.minSamples,
+		MaxSamples:   ct.maxSamples,
+	}
+	if len(ct.successes) > 0 {
+		stats.MeanSuccess = mean(ct.successes)
+	}
+	if len(ct.failures) > 0 {
+		stats.MeanFailure = mean(ct.failures)
+	}
+	if len(ct.successes) >= ct.minSamples && len(ct.failures) >= ct.minSamples {
+		stats.Adaptive = true
+		stats.CurrentThreshold = (stats.MeanSuccess + stats.MeanFailure) / 2.0
+		if stats.CurrentThreshold < 0 {
+			stats.CurrentThreshold = 0
+		}
+		if stats.CurrentThreshold > 1 {
+			stats.CurrentThreshold = 1
+		}
+		return stats
+	}
+	stats.CurrentThreshold = defaultThreshold
+	return stats
+}
+
+func appendWithRing(values []float64, v float64, max int) []float64 {
+	values = append(values, v)
+	if len(values) <= max {
+		return values
+	}
+	start := len(values) - max
+	trimmed := make([]float64, max)
+	copy(trimmed, values[start:])
+	return trimmed
+}
+
+func mean(values []float64) float64 {
+	if len(values) == 0 {
+		return 0
+	}
+	var total float64
+	for _, v := range values {
+		total += v
+	}
+	return total / float64(len(values))
+}

--- a/recovery/confidence_tracker_test.go
+++ b/recovery/confidence_tracker_test.go
@@ -1,0 +1,47 @@
+package recovery
+
+import (
+	"math"
+	"testing"
+)
+
+func TestConfidenceTracker_DefaultThresholdWhenInsufficientSamples(t *testing.T) {
+	ct := NewConfidenceTracker(10, 3)
+	ct.Record(0.9, true)
+	ct.Record(0.2, false)
+
+	got := ct.OptimalThresholdWithDefault(0.4)
+	if got != 0.4 {
+		t.Fatalf("expected default threshold 0.4 with insufficient samples, got %f", got)
+	}
+}
+
+func TestConfidenceTracker_AdaptsAfterMinSamples(t *testing.T) {
+	ct := NewConfidenceTracker(20, 2)
+	ct.Record(0.8, true)
+	ct.Record(0.9, true)
+	ct.Record(0.2, false)
+	ct.Record(0.3, false)
+
+	got := ct.OptimalThresholdWithDefault(0.4)
+	want := (0.85 + 0.25) / 2.0
+	if math.Abs(got-want) > 1e-9 {
+		t.Fatalf("adaptive threshold mismatch: got %f want %f", got, want)
+	}
+}
+
+func TestConfidenceTracker_RingBufferCapsSamples(t *testing.T) {
+	ct := NewConfidenceTracker(3, 1)
+	for i := 1; i <= 5; i++ {
+		ct.Record(float64(i)/10.0, true)
+		ct.Record(float64(i)/20.0, false)
+	}
+
+	stats := ct.Stats(0.4)
+	if stats.SuccessCount != 3 {
+		t.Fatalf("expected 3 success samples retained, got %d", stats.SuccessCount)
+	}
+	if stats.FailureCount != 3 {
+		t.Fatalf("expected 3 failure samples retained, got %d", stats.FailureCount)
+	}
+}

--- a/recovery/engine.go
+++ b/recovery/engine.go
@@ -92,6 +92,7 @@ type RecoveryEngine struct {
 	Refresh     SnapshotRefresher
 	ResolveNode NodeIDResolver
 	BuildDescs  DescriptorBuilder
+	Confidence  *ConfidenceTracker
 }
 
 func NewRecoveryEngine(
@@ -109,6 +110,7 @@ func NewRecoveryEngine(
 		Refresh:     refresh,
 		ResolveNode: resolve,
 		BuildDescs:  buildDescs,
+		Confidence:  NewConfidenceTracker(200, 20),
 	}
 }
 
@@ -172,6 +174,11 @@ func (re *RecoveryEngine) attemptRecovery(
 		maxRetries = 1
 	}
 
+	threshold := re.Config.MinConfidence
+	if re.Confidence != nil {
+		threshold = re.Confidence.OptimalThresholdWithDefault(re.Config.MinConfidence)
+	}
+
 	var lastErr error
 	for attempt := 1; attempt <= maxRetries; attempt++ {
 		rr.Attempts = attempt
@@ -190,21 +197,27 @@ func (re *RecoveryEngine) attemptRecovery(
 		}
 
 		result, err := re.Matcher.Find(ctx, query, descs, semantic.FindOptions{
-			Threshold: re.Config.MinConfidence,
+			Threshold: threshold,
 			TopK:      1,
 		})
 		if err != nil {
 			lastErr = fmt.Errorf("matcher: %w", err)
 			continue
 		}
-		if result.BestRef == "" || result.BestScore < re.Config.MinConfidence {
+		if result.BestRef == "" || result.BestScore < threshold {
+			if re.Confidence != nil && result.BestScore > 0 {
+				re.Confidence.Record(result.BestScore, false)
+			}
 			lastErr = fmt.Errorf("no match above threshold %.2f (best: %.2f)",
-				re.Config.MinConfidence, result.BestScore)
+				threshold, result.BestScore)
 			continue
 		}
 
 		conf := semantic.CalibrateConfidence(result.BestScore)
 		if re.Config.PreferHighConfidence && conf == "low" {
+			if re.Confidence != nil {
+				re.Confidence.Record(result.BestScore, false)
+			}
 			lastErr = fmt.Errorf("match confidence too low: %s (%.2f)",
 				conf, result.BestScore)
 			continue
@@ -217,6 +230,9 @@ func (re *RecoveryEngine) attemptRecovery(
 
 		nodeID, ok := re.ResolveNode(tabID, result.BestRef)
 		if !ok {
+			if re.Confidence != nil {
+				re.Confidence.Record(result.BestScore, false)
+			}
 			lastErr = fmt.Errorf("new ref %s not in cache after refresh", result.BestRef)
 			continue
 		}
@@ -224,10 +240,16 @@ func (re *RecoveryEngine) attemptRecovery(
 		actionResult, execErr := exec(ctx, kind, nodeID)
 		rr.LatencyMs = time.Since(start).Milliseconds()
 		if execErr != nil {
+			if re.Confidence != nil {
+				re.Confidence.Record(result.BestScore, false)
+			}
 			lastErr = execErr
 			continue
 		}
 
+		if re.Confidence != nil {
+			re.Confidence.Record(result.BestScore, true)
+		}
 		rr.Recovered = true
 		return rr, actionResult, nil
 	}
@@ -257,4 +279,12 @@ func (re *RecoveryEngine) RecordIntent(tabID, ref string, entry IntentEntry) {
 	if re.IntentCache != nil {
 		re.IntentCache.Store(tabID, ref, entry)
 	}
+}
+
+// ConfidenceStats returns adaptive-threshold diagnostics for observability.
+func (re *RecoveryEngine) ConfidenceStats() ConfidenceStats {
+	if re.Confidence == nil {
+		return ConfidenceStats{CurrentThreshold: re.Config.MinConfidence}
+	}
+	return re.Confidence.Stats(re.Config.MinConfidence)
 }

--- a/recovery/engine_recovery_test.go
+++ b/recovery/engine_recovery_test.go
@@ -3,6 +3,7 @@ package recovery
 import (
 	"context"
 	"fmt"
+	"math"
 	"strings"
 	"testing"
 	"time"
@@ -529,6 +530,70 @@ func TestRecoveryEngine_RecordIntent(t *testing.T) {
 	}
 }
 
+func TestRecoveryEngine_Attempt_UsesAdaptiveThresholdWhenAvailable(t *testing.T) {
+	cache := NewIntentCache(100, 5*time.Minute)
+	cache.Store("tab1", "e1", IntentEntry{Query: "submit"})
+
+	tracker := NewConfidenceTracker(50, 1)
+	tracker.Record(0.9, true)
+	tracker.Record(0.3, false)
+	adaptiveThreshold := tracker.OptimalThresholdWithDefault(0.4)
+
+	var seenThreshold float64
+	matcher := &mockMatcher{
+		findFn: func(_ context.Context, _ string, _ []semantic.ElementDescriptor, opts semantic.FindOptions) (semantic.FindResult, error) {
+			seenThreshold = opts.Threshold
+			return semantic.FindResult{BestRef: "e2", BestScore: 0.7, Strategy: "combined"}, nil
+		},
+	}
+
+	re := NewRecoveryEngine(
+		DefaultRecoveryConfig(),
+		matcher,
+		cache,
+		func(_ context.Context, _ string) error { return nil },
+		func(_, _ string) (int64, bool) { return 10, true },
+		func(_ string) []semantic.ElementDescriptor {
+			return []semantic.ElementDescriptor{{Ref: "e2", Role: "button", Name: "Submit"}}
+		},
+	)
+	re.Confidence = tracker
+
+	_, _, err := re.Attempt(context.Background(), "tab1", "e1", "click",
+		func(_ context.Context, _ string, _ int64) (map[string]any, error) {
+			return map[string]any{"ok": true}, nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if math.Abs(seenThreshold-adaptiveThreshold) > 1e-9 {
+		t.Fatalf("expected adaptive threshold %.6f, got %.6f", adaptiveThreshold, seenThreshold)
+	}
+}
+
+func TestRecoveryEngine_ConfidenceStats_Exposed(t *testing.T) {
+	re := NewRecoveryEngine(
+		DefaultRecoveryConfig(),
+		&mockMatcher{},
+		NewIntentCache(10, time.Minute),
+		nil, nil, nil,
+	)
+	re.Confidence = NewConfidenceTracker(10, 1)
+	re.Confidence.Record(0.8, true)
+	re.Confidence.Record(0.2, false)
+
+	stats := re.ConfidenceStats()
+	if stats.SuccessCount != 1 {
+		t.Fatalf("expected success count 1, got %d", stats.SuccessCount)
+	}
+	if stats.FailureCount != 1 {
+		t.Fatalf("expected failure count 1, got %d", stats.FailureCount)
+	}
+	if !stats.Adaptive {
+		t.Fatalf("expected adaptive=true when min samples are met")
+	}
+}
 func TestRecoveryEngine_RecordIntent_NilCache(t *testing.T) {
 	re := &RecoveryEngine{Config: DefaultRecoveryConfig()}
 	// Should not panic with nil IntentCache.


### PR DESCRIPTION
## Summary
- add `ConfidenceTracker` with bounded ring buffers for recovery success/failure scores
- compute adaptive threshold as midpoint between mean(failures) and mean(successes)
- fall back to configured `MinConfidence` when sample minimum is not met
- wire adaptive threshold into `RecoveryEngine.Attempt` matcher threshold
- record success/failure scores after each scored recovery attempt
- expose diagnostics via `RecoveryEngine.ConfidenceStats()`

## Issue
Closes #6

## Acceptance Mapping
- [x] `ConfidenceTracker` type with ring buffer
- [x] `RecoveryEngine` records success/failure after attempts with scores
- [x] Threshold adapts after minimum sample count (default 20)
- [x] Default threshold used when insufficient samples
- [x] Stats exposed for diagnostics

## Validation
- `go test ./recovery -run "ConfidenceTracker|AdaptiveThreshold|ConfidenceStats|RecordIntent|ScoreBelowThreshold|PreferHighConfidence|Attempt_Success" -count=1 -v`
- `go test -c ./recovery`
