### PR TITLE
feat: add positional and spatial AX signals to lexical scoring

### DIFF
--- a/cmd/semantic/main.go
+++ b/cmd/semantic/main.go
@@ -66,7 +66,6 @@ type snapshotPositional struct {
 	SiblingIndex int    `json:"sibling_index"`
 	SiblingCount int    `json:"sibling_count"`
 	LabelledBy   string `json:"labelled_by"`
-	LabeledBy    string `json:"labeled_by"`
 }
 
 type snapshotElement struct {
@@ -81,7 +80,6 @@ type snapshotElement struct {
 	SiblingIdx  int                 `json:"sibling_index"`
 	SiblingCnt  int                 `json:"sibling_count"`
 	LabelledBy  string              `json:"labelled_by"`
-	LabeledBy   string              `json:"labeled_by"`
 	Positional  *snapshotPositional `json:"positional"`
 }
 
@@ -111,9 +109,6 @@ func loadSnapshot(path string) ([]semantic.ElementDescriptor, error) {
 	descs := make([]semantic.ElementDescriptor, len(elements))
 	for i, e := range elements {
 		labelledBy := e.LabelledBy
-		if labelledBy == "" {
-			labelledBy = e.LabeledBy
-		}
 		depth := e.Depth
 		siblingIdx := e.SiblingIdx
 		siblingCnt := e.SiblingCnt
@@ -129,8 +124,6 @@ func loadSnapshot(path string) ([]semantic.ElementDescriptor, error) {
 			}
 			if e.Positional.LabelledBy != "" {
 				labelledBy = e.Positional.LabelledBy
-			} else if e.Positional.LabeledBy != "" {
-				labelledBy = e.Positional.LabeledBy
 			}
 		}
 

--- a/cmd/semantic/main.go
+++ b/cmd/semantic/main.go
@@ -61,14 +61,28 @@ Flags (find/match):
 }
 
 // snapshotElement is the JSON shape from pinchtab's /snapshot endpoint.
+type snapshotPositional struct {
+	Depth        int    `json:"depth"`
+	SiblingIndex int    `json:"sibling_index"`
+	SiblingCount int    `json:"sibling_count"`
+	LabelledBy   string `json:"labelled_by"`
+	LabeledBy    string `json:"labeled_by"`
+}
+
 type snapshotElement struct {
-	Ref         string `json:"ref"`
-	Role        string `json:"role"`
-	Name        string `json:"name"`
-	Value       string `json:"value"`
-	Interactive bool   `json:"interactive"`
-	Parent      string `json:"parent"`
-	Section     string `json:"section"`
+	Ref         string              `json:"ref"`
+	Role        string              `json:"role"`
+	Name        string              `json:"name"`
+	Value       string              `json:"value"`
+	Interactive bool                `json:"interactive"`
+	Parent      string              `json:"parent"`
+	Section     string              `json:"section"`
+	Depth       int                 `json:"depth"`
+	SiblingIdx  int                 `json:"sibling_index"`
+	SiblingCnt  int                 `json:"sibling_count"`
+	LabelledBy  string              `json:"labelled_by"`
+	LabeledBy   string              `json:"labeled_by"`
+	Positional  *snapshotPositional `json:"positional"`
 }
 
 func loadSnapshot(path string) ([]semantic.ElementDescriptor, error) {
@@ -96,6 +110,30 @@ func loadSnapshot(path string) ([]semantic.ElementDescriptor, error) {
 
 	descs := make([]semantic.ElementDescriptor, len(elements))
 	for i, e := range elements {
+		labelledBy := e.LabelledBy
+		if labelledBy == "" {
+			labelledBy = e.LabeledBy
+		}
+		depth := e.Depth
+		siblingIdx := e.SiblingIdx
+		siblingCnt := e.SiblingCnt
+		if e.Positional != nil {
+			if e.Positional.Depth != 0 {
+				depth = e.Positional.Depth
+			}
+			if e.Positional.SiblingIndex != 0 {
+				siblingIdx = e.Positional.SiblingIndex
+			}
+			if e.Positional.SiblingCount != 0 {
+				siblingCnt = e.Positional.SiblingCount
+			}
+			if e.Positional.LabelledBy != "" {
+				labelledBy = e.Positional.LabelledBy
+			} else if e.Positional.LabeledBy != "" {
+				labelledBy = e.Positional.LabeledBy
+			}
+		}
+
 		descs[i] = semantic.ElementDescriptor{
 			Ref:         e.Ref,
 			Role:        e.Role,
@@ -104,6 +142,12 @@ func loadSnapshot(path string) ([]semantic.ElementDescriptor, error) {
 			Interactive: e.Interactive,
 			Parent:      e.Parent,
 			Section:     e.Section,
+			Positional: semantic.PositionalHints{
+				Depth:        depth,
+				SiblingIndex: siblingIdx,
+				SiblingCount: siblingCnt,
+				LabelledBy:   labelledBy,
+			},
 		}
 	}
 	return descs, nil

--- a/cmd/semantic/main_test.go
+++ b/cmd/semantic/main_test.go
@@ -12,8 +12,8 @@ func TestLoadSnapshot_PropagatesInteractiveFlag(t *testing.T) {
 	}
 
 	json := `[
-		{"ref":"e1","role":"button","name":"Submit","interactive":true,"parent":"Login form","section":"Authentication"},
-		{"ref":"e2","role":"text","name":"Submit","interactive":false,"parent":"Payment form","section":"Checkout"}
+		{"ref":"e1","role":"button","name":"Submit","interactive":true,"parent":"Login form","section":"Authentication","depth":3,"sibling_index":1,"sibling_count":2,"labelled_by":"Primary Action"},
+		{"ref":"e2","role":"text","name":"Submit","interactive":false,"parent":"Payment form","section":"Checkout","positional":{"depth":2,"sibling_index":0,"sibling_count":1,"labeled_by":"Secondary Action"}}
 	]`
 	if _, err := f.WriteString(json); err != nil {
 		t.Fatalf("WriteString failed: %v", err)
@@ -38,6 +38,18 @@ func TestLoadSnapshot_PropagatesInteractiveFlag(t *testing.T) {
 	if descs[0].Section != "Authentication" {
 		t.Fatalf("expected first descriptor section=Authentication, got %q", descs[0].Section)
 	}
+	if descs[0].Positional.Depth != 3 {
+		t.Fatalf("expected first descriptor depth=3, got %d", descs[0].Positional.Depth)
+	}
+	if descs[0].Positional.SiblingIndex != 1 {
+		t.Fatalf("expected first descriptor sibling index=1, got %d", descs[0].Positional.SiblingIndex)
+	}
+	if descs[0].Positional.SiblingCount != 2 {
+		t.Fatalf("expected first descriptor sibling count=2, got %d", descs[0].Positional.SiblingCount)
+	}
+	if descs[0].Positional.LabelledBy != "Primary Action" {
+		t.Fatalf("expected first descriptor labelled_by=Primary Action, got %q", descs[0].Positional.LabelledBy)
+	}
 	if descs[1].Interactive {
 		t.Fatalf("expected second descriptor interactive=false")
 	}
@@ -46,5 +58,17 @@ func TestLoadSnapshot_PropagatesInteractiveFlag(t *testing.T) {
 	}
 	if descs[1].Section != "Checkout" {
 		t.Fatalf("expected second descriptor section=Checkout, got %q", descs[1].Section)
+	}
+	if descs[1].Positional.Depth != 2 {
+		t.Fatalf("expected second descriptor depth=2, got %d", descs[1].Positional.Depth)
+	}
+	if descs[1].Positional.SiblingIndex != 0 {
+		t.Fatalf("expected second descriptor sibling index=0, got %d", descs[1].Positional.SiblingIndex)
+	}
+	if descs[1].Positional.SiblingCount != 1 {
+		t.Fatalf("expected second descriptor sibling count=1, got %d", descs[1].Positional.SiblingCount)
+	}
+	if descs[1].Positional.LabelledBy != "Secondary Action" {
+		t.Fatalf("expected second descriptor labelled_by=Secondary Action, got %q", descs[1].Positional.LabelledBy)
 	}
 }

--- a/cmd/semantic/main_test.go
+++ b/cmd/semantic/main_test.go
@@ -13,7 +13,7 @@ func TestLoadSnapshot_PropagatesInteractiveFlag(t *testing.T) {
 
 	json := `[
 		{"ref":"e1","role":"button","name":"Submit","interactive":true,"parent":"Login form","section":"Authentication","depth":3,"sibling_index":1,"sibling_count":2,"labelled_by":"Primary Action"},
-		{"ref":"e2","role":"text","name":"Submit","interactive":false,"parent":"Payment form","section":"Checkout","positional":{"depth":2,"sibling_index":0,"sibling_count":1,"labeled_by":"Secondary Action"}}
+		{"ref":"e2","role":"text","name":"Submit","interactive":false,"parent":"Payment form","section":"Checkout","positional":{"depth":2,"sibling_index":0,"sibling_count":1,"labelled_by":"Secondary Action"}}
 	]`
 	if _, err := f.WriteString(json); err != nil {
 		t.Fatalf("WriteString failed: %v", err)

--- a/internal/engine/lexical.go
+++ b/internal/engine/lexical.go
@@ -26,6 +26,10 @@ const (
 	interactiveActionBoost = 0.10
 	// interactiveBaseBoost lightly favors interactive elements for generic queries.
 	interactiveBaseBoost = 0.05
+	// positionalLabelBoost rewards label associations matching the query.
+	positionalLabelBoost = 0.15
+	// positionalUniqueSiblingBoost rewards singleton role elements in a group.
+	positionalUniqueSiblingBoost = 0.03
 )
 
 // LexicalMatcher scores elements using Jaccard similarity with synonym
@@ -55,13 +59,34 @@ func (m *LexicalMatcher) Find(_ context.Context, query string, elements []types.
 	for _, el := range elements {
 		composite := el.Composite()
 		score := lexicalScore(query, composite, el.Interactive, ef)
+		score += positionalBoost(query, el.Positional)
+		if score > 1.0 {
+			score = 1.0
+		}
 		if score >= opts.Threshold {
 			candidates = append(candidates, scored{desc: el, score: score})
 		}
 	}
 
 	sort.Slice(candidates, func(i, j int) bool {
-		return candidates[i].score > candidates[j].score
+		scoreDiff := candidates[i].score - candidates[j].score
+		if math.Abs(scoreDiff) > 1e-9 {
+			return scoreDiff > 0
+		}
+
+		depthI := candidates[i].desc.Positional.Depth
+		depthJ := candidates[j].desc.Positional.Depth
+		if depthI != depthJ {
+			return depthI > depthJ
+		}
+
+		idxI := candidates[i].desc.Positional.SiblingIndex
+		idxJ := candidates[j].desc.Positional.SiblingIndex
+		if idxI != idxJ {
+			return idxI < idxJ
+		}
+
+		return candidates[i].desc.Ref < candidates[j].desc.Ref
 	})
 
 	if len(candidates) > opts.TopK {
@@ -322,6 +347,42 @@ func interactiveBoost(qTokens []string, isInteractive bool) float64 {
 		return interactiveActionBoost
 	}
 	return interactiveBaseBoost
+}
+
+func positionalBoost(query string, hints types.PositionalHints) float64 {
+	boost := 0.0
+	if hints.SiblingCount == 1 {
+		boost += positionalUniqueSiblingBoost
+	}
+	if hints.LabelledBy != "" && labelMatchesQuery(query, hints.LabelledBy) {
+		boost += positionalLabelBoost
+	}
+	return boost
+}
+
+func labelMatchesQuery(query, labelledBy string) bool {
+	qTokens := tokenize(query)
+	lTokens := tokenize(labelledBy)
+
+	qTokens = removeStopwordsContextAware(qTokens, lTokens)
+	lTokens = removeStopwordsContextAware(lTokens, qTokens)
+	if len(qTokens) == 0 || len(lTokens) == 0 {
+		return false
+	}
+
+	qSet := tokenSet(qTokens)
+	lSet := tokenSet(lTokens)
+	matched := 0
+	for t := range qSet {
+		if lSet[t] {
+			matched++
+		}
+	}
+	if matched == 0 {
+		return false
+	}
+
+	return matched*2 >= len(qSet)
 }
 
 func containsActionVerb(tokens []string) bool {

--- a/internal/engine/lexical_test.go
+++ b/internal/engine/lexical_test.go
@@ -337,6 +337,54 @@ func TestLexicalMatcher_SectionContextDisambiguatesSubmitButtons(t *testing.T) {
 	}
 }
 
+func TestLexicalMatcher_LabelledByBoostPrefersAssociatedInput(t *testing.T) {
+	m := NewLexicalMatcher()
+	elements := []types.ElementDescriptor{
+		{Ref: "work-email", Role: "textbox", Name: "Email", Positional: types.PositionalHints{LabelledBy: "Work Email"}},
+		{Ref: "billing-email", Role: "textbox", Name: "Email", Positional: types.PositionalHints{LabelledBy: "Billing Email"}},
+	}
+
+	result, err := m.Find(context.Background(), "work email input", elements, types.FindOptions{Threshold: 0, TopK: 2})
+	if err != nil {
+		t.Fatalf("Find returned error: %v", err)
+	}
+	if result.BestRef != "work-email" {
+		t.Fatalf("expected labelled input to win, got %s", result.BestRef)
+	}
+}
+
+func TestLexicalMatcher_SiblingUniquenessBoostPrefersSingleton(t *testing.T) {
+	m := NewLexicalMatcher()
+	elements := []types.ElementDescriptor{
+		{Ref: "single-search", Role: "searchbox", Name: "Search", Positional: types.PositionalHints{SiblingCount: 1}},
+		{Ref: "group-search", Role: "searchbox", Name: "Search", Positional: types.PositionalHints{SiblingCount: 3}},
+	}
+
+	result, err := m.Find(context.Background(), "search box", elements, types.FindOptions{Threshold: 0, TopK: 2})
+	if err != nil {
+		t.Fatalf("Find returned error: %v", err)
+	}
+	if result.BestRef != "single-search" {
+		t.Fatalf("expected singleton sibling to rank first, got %s", result.BestRef)
+	}
+}
+
+func TestLexicalMatcher_DepthBreaksEqualScores(t *testing.T) {
+	m := NewLexicalMatcher()
+	elements := []types.ElementDescriptor{
+		{Ref: "shallow", Role: "button", Name: "Submit", Positional: types.PositionalHints{Depth: 1}},
+		{Ref: "deep", Role: "button", Name: "Submit", Positional: types.PositionalHints{Depth: 4}},
+	}
+
+	result, err := m.Find(context.Background(), "submit button", elements, types.FindOptions{Threshold: 0, TopK: 2})
+	if err != nil {
+		t.Fatalf("Find returned error: %v", err)
+	}
+	if result.BestRef != "deep" {
+		t.Fatalf("expected deeper element to rank first on tied scores, got %s", result.BestRef)
+	}
+}
+
 func TestElementFrequency_IEF_RareTokenHigherThanCommon(t *testing.T) {
 	elements := []types.ElementDescriptor{
 		{Ref: "e1", Role: "button", Name: "Checkout"},

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -76,6 +76,14 @@ type MatchExplain struct {
 	Composite      string  `json:"composite"`
 }
 
+// PositionalHints captures optional AX-tree relationship and position metadata.
+type PositionalHints struct {
+	Depth        int
+	SiblingIndex int
+	SiblingCount int
+	LabelledBy   string
+}
+
 // ElementDescriptor describes a single accessibility tree node.
 type ElementDescriptor struct {
 	Ref         string
@@ -85,6 +93,7 @@ type ElementDescriptor struct {
 	Interactive bool
 	Parent      string
 	Section     string
+	Positional  PositionalHints
 }
 
 // Composite returns a single string combining role, name, and value

--- a/semantic.go
+++ b/semantic.go
@@ -23,6 +23,9 @@ type Embedder = types.Embedder
 // ElementDescriptor describes a single accessibility tree node.
 type ElementDescriptor = types.ElementDescriptor
 
+// PositionalHints captures optional AX-tree relationship metadata.
+type PositionalHints = types.PositionalHints
+
 // ElementMatch is a single scored match.
 type ElementMatch = types.ElementMatch
 

--- a/semantic_test.go
+++ b/semantic_test.go
@@ -86,3 +86,22 @@ func TestElementDescriptor_Composite_IncludesSection(t *testing.T) {
 		t.Errorf("unexpected composite with section: %q", d.Composite())
 	}
 }
+
+func TestElementDescriptor_PositionalHints(t *testing.T) {
+	d := semantic.ElementDescriptor{
+		Role: "textbox",
+		Name: "Email",
+		Positional: semantic.PositionalHints{
+			Depth:        3,
+			SiblingIndex: 1,
+			SiblingCount: 2,
+			LabelledBy:   "Work Email",
+		},
+	}
+	if d.Positional.Depth != 3 {
+		t.Errorf("unexpected depth: %d", d.Positional.Depth)
+	}
+	if d.Positional.LabelledBy != "Work Email" {
+		t.Errorf("unexpected labelled_by: %q", d.Positional.LabelledBy)
+	}
+}


### PR DESCRIPTION
## Summary
- add `PositionalHints` to element descriptors (`Depth`, `SiblingIndex`, `SiblingCount`, `LabelledBy`)
- parse positional metadata from snapshot JSON in both flat and nested (`positional`) shapes
- add positional lexical modifiers:
  - label association boost when query aligns with `LabelledBy`
  - small boost for singleton siblings (`SiblingCount == 1`)
- add deterministic tie-break for equal scores using `Depth` (deeper preferred), then sibling index/ref for stable ordering
- add unit tests for label association, sibling uniqueness, depth tiebreak, and snapshot propagation

## Issue
Closes #7

## Acceptance Mapping
- [x] PositionalHints added alongside ElementDescriptor
- [x] Label association extracted from snapshot/AX metadata (`labelled_by` / `labeled_by`)
- [x] Label match contributes to score
- [x] Depth used as tiebreak when scores equal
- [x] Unit tests with form elements and labels

## Validation
- `go test ./internal/engine -run "SectionContext|LabelledByBoost|SiblingUniqueness|DepthBreaksEqualScores|ActionQueryPrefersInteractiveElement" -count=1 -v`
- `go test ./cmd/semantic -run LoadSnapshot -count=1 -v`
- `go test . -run "Composite|PositionalHints" -count=1 -v`
- `go test ./... -count=1`

### Web-derived snapshot spot checks (manual)
- `semantic find "work email input" --snapshot testdata/snapshots/login-page.json --format json`
- `semantic find "search wikipedia" --snapshot testdata/snapshots/wikipedia-article.json --format json`
- `semantic find "pull requests tab" --snapshot testdata/snapshots/github-repo.json --format json`
