### PR TITLE
feat(recovery): incremental diff-first matching and recovery metrics

### DIFF
--- a/recovery/diff_search.go
+++ b/recovery/diff_search.go
@@ -1,0 +1,130 @@
+package recovery
+
+import (
+	"strconv"
+	"strings"
+	"sync"
+
+	"github.com/pinchtab/semantic"
+)
+
+// RecoverySearchStats exposes diff-first recovery search metrics.
+type RecoverySearchStats struct {
+	DiffAttempts int     `json:"diff_attempts"`
+	DiffHits     int     `json:"diff_hits"`
+	FullSearches int     `json:"full_searches"`
+	DiffHitRate  float64 `json:"diff_hit_rate"`
+}
+
+// RecoverySearchTracker records diff-first vs full-search behavior.
+type RecoverySearchTracker struct {
+	mu           sync.Mutex
+	diffAttempts int
+	diffHits     int
+	fullSearches int
+}
+
+func NewRecoverySearchTracker() *RecoverySearchTracker {
+	return &RecoverySearchTracker{}
+}
+
+func (rt *RecoverySearchTracker) RecordDiffAttempt() {
+	if rt == nil {
+		return
+	}
+	rt.mu.Lock()
+	rt.diffAttempts++
+	rt.mu.Unlock()
+}
+
+func (rt *RecoverySearchTracker) RecordDiffHit() {
+	if rt == nil {
+		return
+	}
+	rt.mu.Lock()
+	rt.diffHits++
+	rt.mu.Unlock()
+}
+
+func (rt *RecoverySearchTracker) RecordFullSearch() {
+	if rt == nil {
+		return
+	}
+	rt.mu.Lock()
+	rt.fullSearches++
+	rt.mu.Unlock()
+}
+
+func (rt *RecoverySearchTracker) Stats() RecoverySearchStats {
+	if rt == nil {
+		return RecoverySearchStats{}
+	}
+
+	rt.mu.Lock()
+	defer rt.mu.Unlock()
+
+	stats := RecoverySearchStats{
+		DiffAttempts: rt.diffAttempts,
+		DiffHits:     rt.diffHits,
+		FullSearches: rt.fullSearches,
+	}
+	if stats.DiffAttempts > 0 {
+		stats.DiffHitRate = float64(stats.DiffHits) / float64(stats.DiffAttempts)
+	}
+	return stats
+}
+
+// diffDescriptors returns descriptors that are either new or changed in `curr`
+// relative to `prev`, plus descriptors that were removed from `prev`.
+func diffDescriptors(prev, curr []semantic.ElementDescriptor) ([]semantic.ElementDescriptor, []semantic.ElementDescriptor) {
+	prevByRef := make(map[string]semantic.ElementDescriptor, len(prev))
+	for _, d := range prev {
+		if d.Ref == "" {
+			continue
+		}
+		prevByRef[d.Ref] = d
+	}
+
+	changedOrAdded := make([]semantic.ElementDescriptor, 0)
+	seen := make(map[string]bool, len(curr))
+	for _, d := range curr {
+		if d.Ref == "" {
+			changedOrAdded = append(changedOrAdded, d)
+			continue
+		}
+		seen[d.Ref] = true
+		if p, ok := prevByRef[d.Ref]; !ok || descriptorFingerprint(p) != descriptorFingerprint(d) {
+			changedOrAdded = append(changedOrAdded, d)
+		}
+	}
+
+	removed := make([]semantic.ElementDescriptor, 0)
+	for _, d := range prev {
+		if d.Ref == "" {
+			continue
+		}
+		if !seen[d.Ref] {
+			removed = append(removed, d)
+		}
+	}
+
+	return changedOrAdded, removed
+}
+
+func descriptorFingerprint(d semantic.ElementDescriptor) string {
+	var b strings.Builder
+	b.WriteString(d.Ref)
+	b.WriteString("|")
+	b.WriteString(d.Role)
+	b.WriteString("|")
+	b.WriteString(d.Name)
+	b.WriteString("|")
+	b.WriteString(d.Value)
+	b.WriteString("|")
+	b.WriteString(d.Parent)
+	b.WriteString("|")
+	b.WriteString(d.Section)
+	b.WriteString("|")
+	b.WriteString(strconv.FormatBool(d.Interactive))
+	return b.String()
+}

--- a/recovery/diff_search_test.go
+++ b/recovery/diff_search_test.go
@@ -1,0 +1,47 @@
+package recovery
+
+import (
+	"testing"
+
+	"github.com/pinchtab/semantic"
+)
+
+func TestDiffDescriptors_DetectsAddedChangedRemoved(t *testing.T) {
+	prev := []semantic.ElementDescriptor{
+		{Ref: "e1", Role: "button", Name: "Submit"},
+		{Ref: "e2", Role: "textbox", Name: "Email"},
+	}
+	curr := []semantic.ElementDescriptor{
+		{Ref: "e1", Role: "button", Name: "Submit now"}, // changed
+		{Ref: "e3", Role: "button", Name: "Cancel"},     // added
+	}
+
+	diff, removed := diffDescriptors(prev, curr)
+	if len(diff) != 2 {
+		t.Fatalf("expected 2 diff descriptors, got %d", len(diff))
+	}
+	if len(removed) != 1 || removed[0].Ref != "e2" {
+		t.Fatalf("expected e2 removed, got %+v", removed)
+	}
+}
+
+func TestRecoverySearchTracker_Stats(t *testing.T) {
+	tracker := NewRecoverySearchTracker()
+	tracker.RecordDiffAttempt()
+	tracker.RecordDiffHit()
+	tracker.RecordFullSearch()
+
+	stats := tracker.Stats()
+	if stats.DiffAttempts != 1 {
+		t.Fatalf("expected diff attempts=1, got %d", stats.DiffAttempts)
+	}
+	if stats.DiffHits != 1 {
+		t.Fatalf("expected diff hits=1, got %d", stats.DiffHits)
+	}
+	if stats.FullSearches != 1 {
+		t.Fatalf("expected full searches=1, got %d", stats.FullSearches)
+	}
+	if stats.DiffHitRate != 1.0 {
+		t.Fatalf("expected diff hit rate=1.0, got %f", stats.DiffHitRate)
+	}
+}

--- a/recovery/engine.go
+++ b/recovery/engine.go
@@ -174,127 +174,21 @@ func (re *RecoveryEngine) attemptRecovery(
 		return rr, nil, fmt.Errorf("recovery: %s", rr.Error)
 	}
 
-	maxRetries := re.Config.MaxRetries
-	if maxRetries <= 0 {
-		maxRetries = 1
-	}
-
-	threshold := re.Config.MinConfidence
-	if re.Confidence != nil {
-		threshold = re.Confidence.OptimalThresholdWithDefault(re.Config.MinConfidence)
-	}
-
-	var prevDescs []semantic.ElementDescriptor
-	if re.BuildDescs != nil {
-		prevDescs = re.BuildDescs(tabID)
-	}
+	maxRetries := re.maxRetries()
+	threshold := re.recoveryThreshold()
+	prevDescs := re.initialSnapshot(tabID)
 
 	var lastErr error
 	for attempt := 1; attempt <= maxRetries; attempt++ {
 		rr.Attempts = attempt
 
-		if re.Refresh != nil {
-			if err := re.Refresh(ctx, tabID); err != nil {
-				lastErr = fmt.Errorf("refresh snapshot: %w", err)
-				continue
-			}
+		var actionResult map[string]any
+		prevDescs, actionResult, lastErr = re.attemptOnce(ctx, tabID, query, kind, threshold, prevDescs, exec, &rr)
+		if lastErr == nil {
+			rr.Recovered = true
+			rr.LatencyMs = time.Since(start).Milliseconds()
+			return rr, actionResult, nil
 		}
-
-		if re.BuildDescs == nil {
-			lastErr = fmt.Errorf("descriptor builder not configured")
-			continue
-		}
-
-		descs := re.BuildDescs(tabID)
-		if len(descs) == 0 {
-			lastErr = fmt.Errorf("empty snapshot after refresh")
-			continue
-		}
-
-		diffDescs, _ := diffDescriptors(prevDescs, descs)
-		prevDescs = descs
-
-		findOpts := semantic.FindOptions{Threshold: threshold, TopK: 1}
-		usedDiff := false
-
-		result, err := semantic.FindResult{}, error(nil)
-		if len(diffDescs) > 0 {
-			if re.Search != nil {
-				re.Search.RecordDiffAttempt()
-			}
-			result, err = re.Matcher.Find(ctx, query, diffDescs, findOpts)
-			if err == nil && result.BestRef != "" && result.BestScore >= threshold {
-				usedDiff = true
-				if re.Search != nil {
-					re.Search.RecordDiffHit()
-				}
-			}
-		}
-
-		if !usedDiff {
-			if re.Search != nil {
-				re.Search.RecordFullSearch()
-			}
-			result, err = re.Matcher.Find(ctx, query, descs, findOpts)
-		}
-
-		if err != nil {
-			lastErr = fmt.Errorf("matcher: %w", err)
-			continue
-		}
-		if result.BestRef == "" || result.BestScore < threshold {
-			if re.Confidence != nil && result.BestScore > 0 {
-				re.Confidence.Record(result.BestScore, false)
-			}
-			lastErr = fmt.Errorf("no match above threshold %.2f (best: %.2f)",
-				threshold, result.BestScore)
-			continue
-		}
-
-		effectiveScore := result.BestScore
-		if usedDiff {
-			effectiveScore = math.Min(1.0, effectiveScore+diffMatchConfidenceBonus)
-		}
-
-		conf := semantic.CalibrateConfidence(effectiveScore)
-		if re.Config.PreferHighConfidence && conf == "low" {
-			if re.Confidence != nil {
-				re.Confidence.Record(effectiveScore, false)
-			}
-			lastErr = fmt.Errorf("match confidence too low: %s (%.2f)",
-				conf, effectiveScore)
-			continue
-		}
-
-		rr.NewRef = result.BestRef
-		rr.Score = effectiveScore
-		rr.Confidence = conf
-		rr.Strategy = result.Strategy
-
-		nodeID, ok := re.ResolveNode(tabID, result.BestRef)
-		if !ok {
-			if re.Confidence != nil {
-				re.Confidence.Record(result.BestScore, false)
-			}
-			lastErr = fmt.Errorf("new ref %s not in cache after refresh", result.BestRef)
-			continue
-		}
-
-		actionResult, execErr := exec(ctx, kind, nodeID)
-		rr.LatencyMs = time.Since(start).Milliseconds()
-		if execErr != nil {
-			if re.Confidence != nil {
-				re.Confidence.Record(effectiveScore, false)
-			}
-			lastErr = execErr
-			continue
-		}
-
-		if re.Confidence != nil {
-			re.Confidence.Record(effectiveScore, true)
-		}
-		rr.Recovered = true
-		return rr, actionResult, nil
 	}
 
 	rr.LatencyMs = time.Since(start).Milliseconds()
@@ -302,6 +196,157 @@ func (re *RecoveryEngine) attemptRecovery(
 		rr.Error = lastErr.Error()
 	}
 	return rr, nil, lastErr
+}
+
+func (re *RecoveryEngine) attemptOnce(
+	ctx context.Context,
+	tabID string,
+	query string,
+	kind string,
+	threshold float64,
+	prevDescs []semantic.ElementDescriptor,
+	exec ActionExecutor,
+	rr *RecoveryResult,
+) ([]semantic.ElementDescriptor, map[string]any, error) {
+	descs, diffDescs, err := re.refreshAndBuild(tabID, ctx, prevDescs)
+	if err != nil {
+		return prevDescs, nil, err
+	}
+
+	result, usedDiff, err := re.findWithDiffFirst(ctx, query, threshold, diffDescs, descs)
+	if err != nil {
+		return descs, nil, fmt.Errorf("matcher: %w", err)
+	}
+	if result.BestRef == "" || result.BestScore < threshold {
+		re.recordConfidence(result.BestScore, false)
+		return descs, nil, fmt.Errorf("no match above threshold %.2f (best: %.2f)", threshold, result.BestScore)
+	}
+
+	effectiveScore := result.BestScore
+	if usedDiff {
+		effectiveScore = math.Min(1.0, effectiveScore+diffMatchConfidenceBonus)
+	}
+
+	conf := semantic.CalibrateConfidence(effectiveScore)
+	if re.Config.PreferHighConfidence && conf == "low" {
+		re.recordConfidence(effectiveScore, false)
+		return descs, nil, fmt.Errorf("match confidence too low: %s (%.2f)", conf, effectiveScore)
+	}
+
+	rr.NewRef = result.BestRef
+	rr.Score = effectiveScore
+	rr.Confidence = conf
+	rr.Strategy = result.Strategy
+
+	if re.ResolveNode == nil {
+		re.recordConfidence(effectiveScore, false)
+		return descs, nil, fmt.Errorf("node resolver not configured")
+	}
+	nodeID, ok := re.ResolveNode(tabID, result.BestRef)
+	if !ok {
+		re.recordConfidence(result.BestScore, false)
+		return descs, nil, fmt.Errorf("new ref %s not in cache after refresh", result.BestRef)
+	}
+	if exec == nil {
+		re.recordConfidence(effectiveScore, false)
+		return descs, nil, fmt.Errorf("action executor not configured")
+	}
+
+	actionResult, execErr := exec(ctx, kind, nodeID)
+	if execErr != nil {
+		re.recordConfidence(effectiveScore, false)
+		return descs, nil, execErr
+	}
+
+	re.recordConfidence(effectiveScore, true)
+	return descs, actionResult, nil
+}
+
+func (re *RecoveryEngine) refreshAndBuild(
+	tabID string,
+	ctx context.Context,
+	prevDescs []semantic.ElementDescriptor,
+) ([]semantic.ElementDescriptor, []semantic.ElementDescriptor, error) {
+	if re.Refresh != nil {
+		if err := re.Refresh(ctx, tabID); err != nil {
+			return prevDescs, nil, fmt.Errorf("refresh snapshot: %w", err)
+		}
+	}
+	if re.BuildDescs == nil {
+		return prevDescs, nil, fmt.Errorf("descriptor builder not configured")
+	}
+
+	descs := re.BuildDescs(tabID)
+	if len(descs) == 0 {
+		return prevDescs, nil, fmt.Errorf("empty snapshot after refresh")
+	}
+
+	diffDescs, _ := diffDescriptors(prevDescs, descs)
+	return descs, diffDescs, nil
+}
+
+func (re *RecoveryEngine) findWithDiffFirst(
+	ctx context.Context,
+	query string,
+	threshold float64,
+	diffDescs []semantic.ElementDescriptor,
+	descs []semantic.ElementDescriptor,
+) (semantic.FindResult, bool, error) {
+	findOpts := semantic.FindOptions{Threshold: threshold, TopK: 1}
+
+	if len(diffDescs) > 0 {
+		if re.Search != nil {
+			re.Search.RecordDiffAttempt()
+		}
+		result, err := re.Matcher.Find(ctx, query, diffDescs, findOpts)
+		if err != nil {
+			return semantic.FindResult{}, false, err
+		}
+		if result.BestRef != "" && result.BestScore >= threshold {
+			if re.Search != nil {
+				re.Search.RecordDiffHit()
+			}
+			return result, true, nil
+		}
+	}
+
+	if re.Search != nil {
+		re.Search.RecordFullSearch()
+	}
+	result, err := re.Matcher.Find(ctx, query, descs, findOpts)
+	return result, false, err
+}
+
+func (re *RecoveryEngine) maxRetries() int {
+	maxRetries := re.Config.MaxRetries
+	if maxRetries <= 0 {
+		maxRetries = 1
+	}
+	return maxRetries
+}
+
+func (re *RecoveryEngine) recoveryThreshold() float64 {
+	threshold := re.Config.MinConfidence
+	if re.Confidence != nil {
+		threshold = re.Confidence.OptimalThresholdWithDefault(re.Config.MinConfidence)
+	}
+	return threshold
+}
+
+func (re *RecoveryEngine) initialSnapshot(tabID string) []semantic.ElementDescriptor {
+	if re.BuildDescs == nil {
+		return nil
+	}
+	return re.BuildDescs(tabID)
+}
+
+func (re *RecoveryEngine) recordConfidence(score float64, succeeded bool) {
+	if re.Confidence == nil {
+		return
+	}
+	if score > 0 {
+		re.Confidence.Record(score, succeeded)
+	}
 }
 
 func (re *RecoveryEngine) reconstructQuery(tabID, ref string) string {

--- a/recovery/engine.go
+++ b/recovery/engine.go
@@ -3,6 +3,7 @@ package recovery
 import (
 	"context"
 	"fmt"
+	"math"
 	"time"
 
 	"github.com/pinchtab/semantic"
@@ -93,7 +94,10 @@ type RecoveryEngine struct {
 	ResolveNode NodeIDResolver
 	BuildDescs  DescriptorBuilder
 	Confidence  *ConfidenceTracker
+	Search      *RecoverySearchTracker
 }
+
+const diffMatchConfidenceBonus = 0.03
 
 func NewRecoveryEngine(
 	cfg RecoveryConfig,
@@ -111,6 +115,7 @@ func NewRecoveryEngine(
 		ResolveNode: resolve,
 		BuildDescs:  buildDescs,
 		Confidence:  NewConfidenceTracker(200, 20),
+		Search:      NewRecoverySearchTracker(),
 	}
 }
 
@@ -179,6 +184,11 @@ func (re *RecoveryEngine) attemptRecovery(
 		threshold = re.Confidence.OptimalThresholdWithDefault(re.Config.MinConfidence)
 	}
 
+	var prevDescs []semantic.ElementDescriptor
+	if re.BuildDescs != nil {
+		prevDescs = re.BuildDescs(tabID)
+	}
+
 	var lastErr error
 	for attempt := 1; attempt <= maxRetries; attempt++ {
 		rr.Attempts = attempt
@@ -190,16 +200,44 @@ func (re *RecoveryEngine) attemptRecovery(
 			}
 		}
 
+		if re.BuildDescs == nil {
+			lastErr = fmt.Errorf("descriptor builder not configured")
+			continue
+		}
+
 		descs := re.BuildDescs(tabID)
 		if len(descs) == 0 {
 			lastErr = fmt.Errorf("empty snapshot after refresh")
 			continue
 		}
 
-		result, err := re.Matcher.Find(ctx, query, descs, semantic.FindOptions{
-			Threshold: threshold,
-			TopK:      1,
-		})
+		diffDescs, _ := diffDescriptors(prevDescs, descs)
+		prevDescs = descs
+
+		findOpts := semantic.FindOptions{Threshold: threshold, TopK: 1}
+		usedDiff := false
+
+		result, err := semantic.FindResult{}, error(nil)
+		if len(diffDescs) > 0 {
+			if re.Search != nil {
+				re.Search.RecordDiffAttempt()
+			}
+			result, err = re.Matcher.Find(ctx, query, diffDescs, findOpts)
+			if err == nil && result.BestRef != "" && result.BestScore >= threshold {
+				usedDiff = true
+				if re.Search != nil {
+					re.Search.RecordDiffHit()
+				}
+			}
+		}
+
+		if !usedDiff {
+			if re.Search != nil {
+				re.Search.RecordFullSearch()
+			}
+			result, err = re.Matcher.Find(ctx, query, descs, findOpts)
+		}
+
 		if err != nil {
 			lastErr = fmt.Errorf("matcher: %w", err)
 			continue
@@ -213,18 +251,23 @@ func (re *RecoveryEngine) attemptRecovery(
 			continue
 		}
 
-		conf := semantic.CalibrateConfidence(result.BestScore)
+		effectiveScore := result.BestScore
+		if usedDiff {
+			effectiveScore = math.Min(1.0, effectiveScore+diffMatchConfidenceBonus)
+		}
+
+		conf := semantic.CalibrateConfidence(effectiveScore)
 		if re.Config.PreferHighConfidence && conf == "low" {
 			if re.Confidence != nil {
-				re.Confidence.Record(result.BestScore, false)
+				re.Confidence.Record(effectiveScore, false)
 			}
 			lastErr = fmt.Errorf("match confidence too low: %s (%.2f)",
-				conf, result.BestScore)
+				conf, effectiveScore)
 			continue
 		}
 
 		rr.NewRef = result.BestRef
-		rr.Score = result.BestScore
+		rr.Score = effectiveScore
 		rr.Confidence = conf
 		rr.Strategy = result.Strategy
 
@@ -241,14 +284,14 @@ func (re *RecoveryEngine) attemptRecovery(
 		rr.LatencyMs = time.Since(start).Milliseconds()
 		if execErr != nil {
 			if re.Confidence != nil {
-				re.Confidence.Record(result.BestScore, false)
+				re.Confidence.Record(effectiveScore, false)
 			}
 			lastErr = execErr
 			continue
 		}
 
 		if re.Confidence != nil {
-			re.Confidence.Record(result.BestScore, true)
+			re.Confidence.Record(effectiveScore, true)
 		}
 		rr.Recovered = true
 		return rr, actionResult, nil
@@ -287,4 +330,12 @@ func (re *RecoveryEngine) ConfidenceStats() ConfidenceStats {
 		return ConfidenceStats{CurrentThreshold: re.Config.MinConfidence}
 	}
 	return re.Confidence.Stats(re.Config.MinConfidence)
+}
+
+// SearchStats returns diff-first recovery search diagnostics.
+func (re *RecoveryEngine) SearchStats() RecoverySearchStats {
+	if re.Search == nil {
+		return RecoverySearchStats{}
+	}
+	return re.Search.Stats()
 }

--- a/recovery/engine_recovery_test.go
+++ b/recovery/engine_recovery_test.go
@@ -594,6 +594,152 @@ func TestRecoveryEngine_ConfidenceStats_Exposed(t *testing.T) {
 		t.Fatalf("expected adaptive=true when min samples are met")
 	}
 }
+
+func TestRecoveryEngine_Attempt_DiffFirstHit_UsesDiffAndBoostsConfidence(t *testing.T) {
+	cache := NewIntentCache(100, 5*time.Minute)
+	cache.Store("tab1", "e1", IntentEntry{Query: "submit button"})
+
+	prevDescs := []semantic.ElementDescriptor{
+		{Ref: "e1", Role: "button", Name: "Old Submit"},
+		{Ref: "e2", Role: "button", Name: "Cancel"},
+	}
+	newDescs := []semantic.ElementDescriptor{
+		{Ref: "e2", Role: "button", Name: "Cancel"},
+		{Ref: "e9", Role: "button", Name: "Submit"},
+	}
+
+	stage := 0
+	var findSizes []int
+	matcher := &mockMatcher{
+		findFn: func(_ context.Context, _ string, descs []semantic.ElementDescriptor, _ semantic.FindOptions) (semantic.FindResult, error) {
+			findSizes = append(findSizes, len(descs))
+			if len(descs) == 1 && descs[0].Ref == "e9" {
+				return semantic.FindResult{BestRef: "e9", BestScore: 0.59, Strategy: "combined"}, nil
+			}
+			return semantic.FindResult{}, fmt.Errorf("unexpected search scope")
+		},
+	}
+
+	re := NewRecoveryEngine(
+		DefaultRecoveryConfig(),
+		matcher,
+		cache,
+		func(_ context.Context, _ string) error {
+			stage = 1
+			return nil
+		},
+		func(_, ref string) (int64, bool) {
+			if ref == "e9" {
+				return 99, true
+			}
+			return 0, false
+		},
+		func(_ string) []semantic.ElementDescriptor {
+			if stage == 0 {
+				return prevDescs
+			}
+			return newDescs
+		},
+	)
+
+	rr, _, err := re.Attempt(context.Background(), "tab1", "e1", "click",
+		func(_ context.Context, _ string, _ int64) (map[string]any, error) {
+			return map[string]any{"ok": true}, nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !rr.Recovered {
+		t.Fatalf("expected recovery success")
+	}
+	if rr.NewRef != "e9" {
+		t.Fatalf("expected new ref e9, got %s", rr.NewRef)
+	}
+	if rr.Score <= 0.59 {
+		t.Fatalf("expected diff-hit confidence boost over 0.59, got %.4f", rr.Score)
+	}
+	if rr.Confidence != "medium" {
+		t.Fatalf("expected confidence upgraded to medium, got %s", rr.Confidence)
+	}
+	if len(findSizes) != 1 || findSizes[0] != 1 {
+		t.Fatalf("expected diff-only search (one call on one descriptor), got calls=%v", findSizes)
+	}
+
+	stats := re.SearchStats()
+	if stats.DiffAttempts != 1 || stats.DiffHits != 1 || stats.FullSearches != 0 {
+		t.Fatalf("unexpected search stats: %+v", stats)
+	}
+}
+
+func TestRecoveryEngine_Attempt_DiffFallbackToFullSearch(t *testing.T) {
+	cache := NewIntentCache(100, 5*time.Minute)
+	cache.Store("tab1", "e1", IntentEntry{Query: "submit button"})
+
+	prevDescs := []semantic.ElementDescriptor{
+		{Ref: "e1", Role: "button", Name: "Old Submit"},
+		{Ref: "e2", Role: "button", Name: "Cancel"},
+	}
+	newDescs := []semantic.ElementDescriptor{
+		{Ref: "e2", Role: "button", Name: "Cancel"},
+		{Ref: "e9", Role: "button", Name: "Submit"},
+	}
+
+	stage := 0
+	call := 0
+	matcher := &mockMatcher{
+		findFn: func(_ context.Context, _ string, descs []semantic.ElementDescriptor, _ semantic.FindOptions) (semantic.FindResult, error) {
+			call++
+			if call == 1 {
+				if len(descs) != 1 || descs[0].Ref != "e9" {
+					return semantic.FindResult{}, fmt.Errorf("expected first search on diff")
+				}
+				return semantic.FindResult{BestRef: "e9", BestScore: 0.2, Strategy: "combined"}, nil
+			}
+			if len(descs) != 2 {
+				return semantic.FindResult{}, fmt.Errorf("expected fallback on full snapshot")
+			}
+			return semantic.FindResult{BestRef: "e9", BestScore: 0.9, Strategy: "combined"}, nil
+		},
+	}
+
+	re := NewRecoveryEngine(
+		DefaultRecoveryConfig(),
+		matcher,
+		cache,
+		func(_ context.Context, _ string) error {
+			stage = 1
+			return nil
+		},
+		func(_, ref string) (int64, bool) {
+			if ref == "e9" {
+				return 99, true
+			}
+			return 0, false
+		},
+		func(_ string) []semantic.ElementDescriptor {
+			if stage == 0 {
+				return prevDescs
+			}
+			return newDescs
+		},
+	)
+
+	_, _, err := re.Attempt(context.Background(), "tab1", "e1", "click",
+		func(_ context.Context, _ string, _ int64) (map[string]any, error) {
+			return map[string]any{"ok": true}, nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	stats := re.SearchStats()
+	if stats.DiffAttempts != 1 || stats.DiffHits != 0 || stats.FullSearches != 1 {
+		t.Fatalf("unexpected search stats: %+v", stats)
+	}
+}
+
 func TestRecoveryEngine_RecordIntent_NilCache(t *testing.T) {
 	re := &RecoveryEngine{Config: DefaultRecoveryConfig()}
 	// Should not panic with nil IntentCache.


### PR DESCRIPTION
## Summary
- add `diffDescriptors(prev, curr)` to detect added/changed descriptors (plus removed)
- update `RecoveryEngine.Attempt` to perform **diff-first** matching, then fallback to full snapshot search
- add small confidence bonus for successful diff-hit matches to reflect stronger locality signal
- add `RecoverySearchTracker` metrics for:
  - diff attempts
  - diff hits
  - full-search fallbacks
- expose diagnostics via `RecoveryEngine.SearchStats()`
- add tests for diff detection, diff-hit path, fallback path, and metrics tracking

## Issue
Closes #8

## Acceptance Mapping
- [x] `diffDescriptors()` function comparing descriptor slices
- [x] Recovery tries diff-first, falls back to full search
- [x] Higher confidence when match found in diff
- [x] Metrics tracking diff-hit vs full-search recovery rates
- [x] Unit tests with simulated re-renders

## Validation
- `go test ./recovery -run "DiffDescriptors|RecoverySearchTracker|DiffFirst|DiffFallback|AdaptiveThreshold|ConfidenceStats|Attempt_Success" -count=1 -v`
- `go test ./... -count=1`

### Random web-derived snapshot checks
- `semantic find "log out" --snapshot testdata/snapshots/dashboard.json --format json`
- `semantic find "pull requests tab" --snapshot testdata/snapshots/github-repo.json --format json`
- `semantic find "add to cart" --snapshot testdata/snapshots/ecommerce-product.json --format json`
