### PR TITLE
feat: solve issues #9 and #10 (typo tolerance + neighbor-aware embeddings)

### DIFF
--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -23,6 +23,7 @@ func NewCombinedMatcher(embedder Embedder) ElementMatcher
 // Standalone matchers
 func NewLexicalMatcher() ElementMatcher
 func NewEmbeddingMatcher(e Embedder) ElementMatcher
+func NewEmbeddingMatcherWithNeighborWeight(e Embedder, weight float64) ElementMatcher
 
 // Built-in embedder (feature hashing, zero deps)
 func NewHashingEmbedder(dim int) Embedder

--- a/internal/engine/benchmark_test.go
+++ b/internal/engine/benchmark_test.go
@@ -76,6 +76,24 @@ func BenchmarkLexicalFind_200Elements(b *testing.B) {
 	}
 }
 
+func BenchmarkLexicalFind_TypoQuery_200Elements(b *testing.B) {
+	m := NewLexicalMatcher()
+	base := benchElements()
+	elements := make([]types.ElementDescriptor, 0, 200)
+	for len(elements) < 200 {
+		elements = append(elements, base...)
+	}
+	elements = elements[:200]
+
+	ctx := context.Background()
+	opts := types.FindOptions{Threshold: 0.0, TopK: 3}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _ = m.Find(ctx, "setttings", elements, opts)
+	}
+}
+
 func BenchmarkHashingEmbed(b *testing.B) {
 	h := NewHashingEmbedder(128)
 	texts := []string{"sign in button"}
@@ -98,6 +116,18 @@ func BenchmarkHashingEmbed_Long(b *testing.B) {
 
 func BenchmarkEmbeddingFind(b *testing.B) {
 	m := NewEmbeddingMatcher(NewHashingEmbedder(128))
+	elements := benchElements()
+	ctx := context.Background()
+	opts := types.FindOptions{Threshold: 0.3, TopK: 3}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _ = m.Find(ctx, "sign in button", elements, opts)
+	}
+}
+
+func BenchmarkEmbeddingFind_NoNeighborContext(b *testing.B) {
+	m := NewEmbeddingMatcherWithNeighborWeight(NewHashingEmbedder(128), 0)
 	elements := benchElements()
 	ctx := context.Background()
 	opts := types.FindOptions{Threshold: 0.3, TopK: 3}

--- a/internal/engine/embedding.go
+++ b/internal/engine/embedding.go
@@ -20,12 +20,27 @@ type Embedder interface {
 // EmbeddingMatcher scores elements using cosine similarity on dense
 // vectors produced by an Embedder.
 type EmbeddingMatcher struct {
-	embedder Embedder
+	embedder       Embedder
+	neighborWeight float32
 }
+
+const defaultNeighborWeight float32 = 0.10
 
 // NewEmbeddingMatcher creates an embedding-based matcher.
 func NewEmbeddingMatcher(e Embedder) *EmbeddingMatcher {
-	return &EmbeddingMatcher{embedder: e}
+	return NewEmbeddingMatcherWithNeighborWeight(e, float64(defaultNeighborWeight))
+}
+
+// NewEmbeddingMatcherWithNeighborWeight creates an embedding matcher and sets
+// how much immediate neighbors influence each element embedding.
+func NewEmbeddingMatcherWithNeighborWeight(e Embedder, weight float64) *EmbeddingMatcher {
+	if weight < 0 {
+		weight = 0
+	}
+	if weight > 1 {
+		weight = 1
+	}
+	return &EmbeddingMatcher{embedder: e, neighborWeight: float32(weight)}
 }
 
 func (m *EmbeddingMatcher) Strategy() string {
@@ -52,6 +67,10 @@ func (m *EmbeddingMatcher) Find(_ context.Context, query string, elements []type
 
 	queryVec := vectors[0]
 	elemVecs := vectors[1:]
+	contextVecs := elemVecs
+	if m.neighborWeight > 0 && len(elemVecs) > 1 {
+		contextVecs = m.withNeighborContext(elemVecs)
+	}
 
 	type scored struct {
 		desc  types.ElementDescriptor
@@ -60,7 +79,7 @@ func (m *EmbeddingMatcher) Find(_ context.Context, query string, elements []type
 
 	var candidates []scored
 	for i, el := range elements {
-		sim := CosineSimilarity(queryVec, elemVecs[i])
+		sim := CosineSimilarity(queryVec, contextVecs[i])
 		if sim >= opts.Threshold {
 			candidates = append(candidates, scored{desc: el, score: sim})
 		}
@@ -94,6 +113,43 @@ func (m *EmbeddingMatcher) Find(_ context.Context, query string, elements []type
 	}
 
 	return result, nil
+}
+
+func (m *EmbeddingMatcher) withNeighborContext(base [][]float32) [][]float32 {
+	contextual := make([][]float32, len(base))
+	for i := range base {
+		vec := make([]float32, len(base[i]))
+		copy(vec, base[i])
+
+		if i > 0 {
+			for d := range vec {
+				vec[d] += base[i-1][d] * m.neighborWeight
+			}
+		}
+		if i+1 < len(base) {
+			for d := range vec {
+				vec[d] += base[i+1][d] * m.neighborWeight
+			}
+		}
+
+		normalizeDenseVector(vec)
+		contextual[i] = vec
+	}
+	return contextual
+}
+
+func normalizeDenseVector(vec []float32) {
+	var norm float64
+	for _, v := range vec {
+		norm += float64(v) * float64(v)
+	}
+	if norm == 0 {
+		return
+	}
+	invNorm := float32(1.0 / math.Sqrt(norm))
+	for i := range vec {
+		vec[i] *= invNorm
+	}
 }
 
 // CosineSimilarity computes the cosine similarity between two float32 vectors.

--- a/internal/engine/embedding_test.go
+++ b/internal/engine/embedding_test.go
@@ -2,6 +2,7 @@ package engine
 
 import (
 	"context"
+	"fmt"
 	"github.com/pinchtab/semantic/internal/types"
 	"math"
 	"testing"
@@ -112,6 +113,25 @@ func TestEmbeddingMatcher_Strategy(t *testing.T) {
 	}
 }
 
+func TestNewEmbeddingMatcher_DefaultNeighborWeight(t *testing.T) {
+	m := NewEmbeddingMatcher(newDummyEmbedder(64))
+	if math.Abs(float64(m.neighborWeight-defaultNeighborWeight)) > 1e-6 {
+		t.Errorf("expected default neighborWeight=%f, got %f", defaultNeighborWeight, m.neighborWeight)
+	}
+}
+
+func TestNewEmbeddingMatcherWithNeighborWeight_ClampsRange(t *testing.T) {
+	below := NewEmbeddingMatcherWithNeighborWeight(newDummyEmbedder(64), -0.25)
+	if below.neighborWeight != 0 {
+		t.Errorf("expected neighborWeight to clamp to 0, got %f", below.neighborWeight)
+	}
+
+	above := NewEmbeddingMatcherWithNeighborWeight(newDummyEmbedder(64), 2)
+	if above.neighborWeight != 1 {
+		t.Errorf("expected neighborWeight to clamp to 1, got %f", above.neighborWeight)
+	}
+}
+
 func TestEmbeddingMatcher_Find(t *testing.T) {
 	m := NewEmbeddingMatcher(newDummyEmbedder(64))
 
@@ -165,6 +185,113 @@ func TestEmbeddingMatcher_ThresholdFiltering(t *testing.T) {
 			t.Errorf("match %s score %f below threshold 0.99", m.Ref, m.Score)
 		}
 	}
+}
+
+func TestEmbeddingMatcher_NeighborContextDisambiguatesRealWorldButtons(t *testing.T) {
+	e := newScriptedEmbedder(map[string][]float32{
+		"laptop add to cart":         {1, 1, 0},
+		"heading: Gaming Laptop Pro": {0, 1, 0},
+		"button: Add to cart":        {1, 0, 0},
+		"heading: Running Shoes":     {0, 0, 1},
+	})
+
+	elements := []types.ElementDescriptor{
+		{Ref: "title-laptop", Role: "heading", Name: "Gaming Laptop Pro"},
+		{Ref: "add-laptop", Role: "button", Name: "Add to cart"},
+		{Ref: "title-shoes", Role: "heading", Name: "Running Shoes"},
+		{Ref: "add-shoes", Role: "button", Name: "Add to cart"},
+	}
+
+	noCtx := NewEmbeddingMatcherWithNeighborWeight(e, 0)
+	baseRes, err := noCtx.Find(context.Background(), "laptop add to cart", elements, types.FindOptions{Threshold: 0, TopK: 4})
+	if err != nil {
+		t.Fatalf("Find with no context failed: %v", err)
+	}
+	baseLaptop, ok := findMatchScore(baseRes.Matches, "add-laptop")
+	if !ok {
+		t.Fatalf("expected add-laptop result in no-context run")
+	}
+	baseShoes, ok := findMatchScore(baseRes.Matches, "add-shoes")
+	if !ok {
+		t.Fatalf("expected add-shoes result in no-context run")
+	}
+	if math.Abs(baseLaptop-baseShoes) > 1e-9 {
+		t.Fatalf("expected identical button scores without context, got laptop=%.6f shoes=%.6f", baseLaptop, baseShoes)
+	}
+
+	withCtx := NewEmbeddingMatcherWithNeighborWeight(e, 0.2)
+	ctxRes, err := withCtx.Find(context.Background(), "laptop add to cart", elements, types.FindOptions{Threshold: 0, TopK: 4})
+	if err != nil {
+		t.Fatalf("Find with context failed: %v", err)
+	}
+	ctxLaptop, ok := findMatchScore(ctxRes.Matches, "add-laptop")
+	if !ok {
+		t.Fatalf("expected add-laptop result in contextual run")
+	}
+	ctxShoes, ok := findMatchScore(ctxRes.Matches, "add-shoes")
+	if !ok {
+		t.Fatalf("expected add-shoes result in contextual run")
+	}
+	if ctxLaptop <= ctxShoes {
+		t.Fatalf("expected laptop button to rank higher with context, got laptop=%.6f shoes=%.6f", ctxLaptop, ctxShoes)
+	}
+}
+
+func TestEmbeddingMatcher_SingleElement_WithNeighborWeight(t *testing.T) {
+	e := newScriptedEmbedder(map[string][]float32{
+		"open account settings":    {1, 1, 0},
+		"button: Account settings": {1, 1, 0},
+	})
+	m := NewEmbeddingMatcherWithNeighborWeight(e, 0.5)
+
+	res, err := m.Find(context.Background(), "open account settings", []types.ElementDescriptor{
+		{Ref: "settings", Role: "button", Name: "Account settings"},
+	}, types.FindOptions{Threshold: 0, TopK: 1})
+	if err != nil {
+		t.Fatalf("Find failed: %v", err)
+	}
+	if res.BestRef != "settings" {
+		t.Fatalf("expected BestRef=settings, got %s", res.BestRef)
+	}
+	if len(res.Matches) != 1 {
+		t.Fatalf("expected one match, got %d", len(res.Matches))
+	}
+}
+
+type scriptedEmbedder struct {
+	vectors map[string][]float32
+}
+
+func newScriptedEmbedder(vectors map[string][]float32) *scriptedEmbedder {
+	return &scriptedEmbedder{vectors: vectors}
+}
+
+func (s *scriptedEmbedder) Strategy() string {
+	return "scripted"
+}
+
+func (s *scriptedEmbedder) Embed(texts []string) ([][]float32, error) {
+	out := make([][]float32, len(texts))
+	for i, text := range texts {
+		base, ok := s.vectors[text]
+		if !ok {
+			return nil, fmt.Errorf("missing scripted embedding for %q", text)
+		}
+		vec := make([]float32, len(base))
+		copy(vec, base)
+		normalizeDenseVector(vec)
+		out[i] = vec
+	}
+	return out, nil
+}
+
+func findMatchScore(matches []types.ElementMatch, ref string) (float64, bool) {
+	for _, match := range matches {
+		if match.Ref == ref {
+			return match.Score, true
+		}
+	}
+	return 0, false
 }
 
 // FindResult.ConfidenceLabel tests

--- a/internal/engine/lexical.go
+++ b/internal/engine/lexical.go
@@ -30,6 +30,10 @@ const (
 	positionalLabelBoost = 0.15
 	// positionalUniqueSiblingBoost rewards singleton role elements in a group.
 	positionalUniqueSiblingBoost = 0.03
+	// typoBonusPerToken rewards one-edit typos on short tokens.
+	typoBonusPerToken = 0.08
+	// typoBonusCap prevents typo matching from dominating lexical score.
+	typoBonusCap = 0.15
 )
 
 // LexicalMatcher scores elements using Jaccard similarity with synonym
@@ -301,7 +305,10 @@ func lexicalScore(query, desc string, interactive bool, ef *ElementFrequency) fl
 	// --- 6. Interactive boost for action-oriented queries ---
 	interactiveScore := interactiveBoost(qTokens, interactive)
 
-	score := jaccard + synScore + prefixScore + roleBoost + phraseBoost + interactiveScore
+	// --- 7. Typo tolerance bonus (Levenshtein edit distance = 1) ---
+	typoScore := typoBonus(qTokens, dTokens)
+
+	score := jaccard + synScore + prefixScore + roleBoost + phraseBoost + interactiveScore + typoScore
 	if score > 1.0 {
 		score = 1.0
 	}
@@ -392,6 +399,85 @@ func containsActionVerb(tokens []string) bool {
 		}
 	}
 	return false
+}
+
+func typoBonus(qTokens, dTokens []string) float64 {
+	bonus := 0.0
+
+	qSeen := tokenSet(qTokens)
+	for qt := range qSeen {
+		ql := len([]rune(qt))
+		if ql < 3 || ql > 10 {
+			continue
+		}
+
+		for _, dt := range dTokens {
+			if qt == dt {
+				continue
+			}
+			dl := len([]rune(dt))
+			if dl < 3 || dl > 10 {
+				continue
+			}
+			if absInt(ql-dl) > 1 {
+				continue
+			}
+			if levenshtein(qt, dt) == 1 {
+				bonus += typoBonusPerToken
+				break
+			}
+		}
+
+		if bonus >= typoBonusCap {
+			return typoBonusCap
+		}
+	}
+
+	if bonus > typoBonusCap {
+		return typoBonusCap
+	}
+	return bonus
+}
+
+func levenshtein(a, b string) int {
+	ar := []rune(a)
+	br := []rune(b)
+	if len(ar) == 0 {
+		return len(br)
+	}
+	if len(br) == 0 {
+		return len(ar)
+	}
+
+	prev := make([]int, len(br)+1)
+	cur := make([]int, len(br)+1)
+	for j := 0; j <= len(br); j++ {
+		prev[j] = j
+	}
+
+	for i := 1; i <= len(ar); i++ {
+		cur[0] = i
+		for j := 1; j <= len(br); j++ {
+			cost := 0
+			if ar[i-1] != br[j-1] {
+				cost = 1
+			}
+			ins := cur[j-1] + 1
+			del := prev[j] + 1
+			sub := prev[j-1] + cost
+			cur[j] = minInt(ins, minInt(del, sub))
+		}
+		prev, cur = cur, prev
+	}
+
+	return prev[len(br)]
+}
+
+func absInt(v int) int {
+	if v < 0 {
+		return -v
+	}
+	return v
 }
 
 func tokenWeight(token string, ef *ElementFrequency) float64 {

--- a/internal/engine/lexical_test.go
+++ b/internal/engine/lexical_test.go
@@ -268,6 +268,49 @@ func TestLexicalScore_PhraseBonus_NoPhraseMatch(t *testing.T) {
 	}
 }
 
+func TestLevenshtein_BasicCases(t *testing.T) {
+	if got := levenshtein("settings", "setttings"); got != 1 {
+		t.Fatalf("expected distance 1, got %d", got)
+	}
+	if got := levenshtein("settings", "setting"); got != 1 {
+		t.Fatalf("expected distance 1, got %d", got)
+	}
+	if got := levenshtein("settings", "setup"); got <= 1 {
+		t.Fatalf("expected distance > 1, got %d", got)
+	}
+}
+
+func TestTypoBonus_EditDistanceOne_GetsBonus(t *testing.T) {
+	bonus := typoBonus(tokenize("setttings"), tokenize("settings"))
+	if bonus <= 0 {
+		t.Fatalf("expected positive typo bonus for edit-distance-1 token")
+	}
+}
+
+func TestTypoBonus_DistanceGreaterThanOne_NoBonus(t *testing.T) {
+	bonus := typoBonus(tokenize("sxyztings"), tokenize("settings"))
+	if bonus != 0 {
+		t.Fatalf("expected no bonus for distance > 1, got %f", bonus)
+	}
+}
+
+func TestTypoBonus_LengthGuards_NoBonus(t *testing.T) {
+	if bonus := typoBonus(tokenize("aa"), tokenize("ab")); bonus != 0 {
+		t.Fatalf("expected no bonus for short token, got %f", bonus)
+	}
+	if bonus := typoBonus(tokenize("extraordinarytoken"), tokenize("extraordimarytoken")); bonus != 0 {
+		t.Fatalf("expected no bonus for long token, got %f", bonus)
+	}
+}
+
+func TestLexicalScore_TypoTolerance_RealWorldSettings(t *testing.T) {
+	withTypo := LexicalScore("setttings", "link: Settings")
+	withoutTypo := LexicalScore("setttings", "link: Billing")
+	if withTypo <= withoutTypo {
+		t.Fatalf("expected typo-tolerant match to score higher, typo=%f control=%f", withTypo, withoutTypo)
+	}
+}
+
 func TestInteractiveBoost_ActionVerbDetection(t *testing.T) {
 	if !containsActionVerb(tokenize("click submit")) {
 		t.Fatalf("expected action verb detection for action-oriented query")

--- a/semantic.go
+++ b/semantic.go
@@ -69,6 +69,13 @@ func NewEmbeddingMatcher(e Embedder) ElementMatcher {
 	return engine.NewEmbeddingMatcher(e)
 }
 
+// NewEmbeddingMatcherWithNeighborWeight creates a standalone embedding matcher
+// and configures how much immediate neighbors influence each element embedding.
+// Weight is clamped to [0, 1].
+func NewEmbeddingMatcherWithNeighborWeight(e Embedder, weight float64) ElementMatcher {
+	return engine.NewEmbeddingMatcherWithNeighborWeight(e, weight)
+}
+
 // LexicalScore computes lexical similarity between a query and an
 // element description string. Returns [0, 1].
 func LexicalScore(query, desc string) float64 {

--- a/semantic_test.go
+++ b/semantic_test.go
@@ -47,6 +47,14 @@ func TestNewEmbeddingMatcher(t *testing.T) {
 	}
 }
 
+func TestNewEmbeddingMatcherWithNeighborWeight(t *testing.T) {
+	e := semantic.NewHashingEmbedder(64)
+	m := semantic.NewEmbeddingMatcherWithNeighborWeight(e, 0.2)
+	if m.Strategy() != "embedding:hashing" {
+		t.Errorf("expected strategy=embedding:hashing, got %s", m.Strategy())
+	}
+}
+
 func TestCalibrateConfidence(t *testing.T) {
 	if semantic.CalibrateConfidence(0.9) != "high" {
 		t.Error("0.9 should be high")


### PR DESCRIPTION
## Summary
This PR completes issues #9 and #10 in one batch:

1. Issue #9: Typo tolerance for lexical matching
- Adds Levenshtein-based typo bonus for edit-distance-1 token pairs.
- Includes length guards and bonus cap to prevent over-boosting.
- Adds focused typo tests and a typo benchmark case.

2. Issue #10: Neighbor-aware embeddings
- Adds immediate-neighbor context blending for embedding vectors.
- Introduces configurable neighbor context weight with clamping to [0, 1] and default 0.10.
- Exposes public constructor for configurable weight.
- Adds disambiguation tests and benchmark comparison with context disabled.

## API
- Added:
  - `NewEmbeddingMatcherWithNeighborWeight(e Embedder, weight float64) ElementMatcher`

## Files
- docs/reference/api.md
- internal/engine/benchmark_test.go
- internal/engine/embedding.go
- internal/engine/embedding_test.go
- internal/engine/lexical.go
- internal/engine/lexical_test.go
- semantic.go
- semantic_test.go

## Validation Performed
- `go test -count=1 ./...`
- `go test ./internal/engine -run "TestLexicalScore_TypoTolerance_RealWorldSettings|TestEmbeddingMatcher_NeighborContextDisambiguatesRealWorldButtons|TestEmbeddingMatcher_SingleElement_WithNeighborWeight" -count=1`
- `go test ./internal/engine -run ^$ -bench . -benchtime=1x`
- Manual CLI checks on real snapshots:
  - `go run ./cmd/semantic find "login button" --snapshot testdata/snapshots/login-page.json --top-k 3 --format table`
  - `go run ./cmd/semantic find "add to cart" --snapshot testdata/snapshots/ecommerce-product.json --top-k 5 --format refs`
  - `go run ./cmd/semantic match "add to cart" e10 --snapshot testdata/snapshots/ecommerce-product.json`
  - `go run ./cmd/semantic classify "node is detached from document"`

## Environment Notes
- `go test -race ./...` could not run on this Windows environment due local cgo/compiler limitation.
- `bash scripts/check.sh` and `bash scripts/e2e.sh` could not run because WSL is not installed on this machine.

Closes #9
Closes #10
