### PR TITLE
feat: support negative qualifiers in queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ Implementations are internal — consumers use the `ElementMatcher` interface an
 ## Features
 
 - **Synonym expansion** — 54 UI synonym groups ("sign in" ↔ "log in", "cart" ↔ "basket", "preferences" ↔ "settings", etc.)
+- **Negative qualifiers** — Exclude contexts inline (`not`, `excluding`, `except`) for duplicate labels across regions
 - **Confidence calibration** — Scores mapped to high (≥ 0.8) / medium (≥ 0.6) / low labels
 - **Error classification** — Classify browser errors (CDP, chromedp) as recoverable or not
 - **Self-healing recovery** — Re-locate stale elements after DOM changes via callback interfaces
@@ -183,6 +184,10 @@ curl -s localhost:9999/snapshot | semantic find "search box"
 semantic find "login" --snapshot page.json --format json    # machine-readable
 semantic find "login" --snapshot page.json --format table   # human-readable
 semantic find "login" --snapshot page.json --format refs    # just refs
+
+# Exclude unwanted regions
+semantic find "submit button not in header" --snapshot page.json
+semantic find "login link, not the footer one" --snapshot page.json
 
 # Score a specific element
 semantic match "login" e4 --snapshot page.json

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -33,6 +33,10 @@ semantic find "login" --snapshot page.json --format json
 
 # Just refs (for piping)
 semantic find "submit" --snapshot page.json --format refs
+
+# Exclude contexts for duplicate labels
+semantic find "submit button not in header" --snapshot page.json
+semantic find "login link, not the footer one" --snapshot page.json
 ```
 
 ### `semantic match`

--- a/internal/engine/embedding.go
+++ b/internal/engine/embedding.go
@@ -52,6 +52,12 @@ func (m *EmbeddingMatcher) Find(_ context.Context, query string, elements []type
 		opts.TopK = 3
 	}
 
+	constraints := parseNegativeConstraints(query)
+	searchQuery := query
+	if constraints.baseQuery != "" {
+		searchQuery = constraints.baseQuery
+	}
+
 	// Build composite descriptions.
 	descs := make([]string, len(elements))
 	for i, el := range elements {
@@ -59,7 +65,7 @@ func (m *EmbeddingMatcher) Find(_ context.Context, query string, elements []type
 	}
 
 	// Embed query + all descriptions in a single batch.
-	texts := append([]string{query}, descs...)
+	texts := append([]string{searchQuery}, descs...)
 	vectors, err := m.embedder.Embed(texts)
 	if err != nil {
 		return types.FindResult{}, err
@@ -79,6 +85,10 @@ func (m *EmbeddingMatcher) Find(_ context.Context, query string, elements []type
 
 	var candidates []scored
 	for i, el := range elements {
+		if shouldExcludeElement(el, constraints.exclusionPhrase) {
+			continue
+		}
+
 		sim := CosineSimilarity(queryVec, contextVecs[i])
 		if sim >= opts.Threshold {
 			candidates = append(candidates, scored{desc: el, score: sim})

--- a/internal/engine/lexical.go
+++ b/internal/engine/lexical.go
@@ -52,6 +52,12 @@ func (m *LexicalMatcher) Find(_ context.Context, query string, elements []types.
 		opts.TopK = 3
 	}
 
+	constraints := parseNegativeConstraints(query)
+	searchQuery := query
+	if constraints.baseQuery != "" {
+		searchQuery = constraints.baseQuery
+	}
+
 	ef := BuildElementFrequency(elements)
 
 	type scored struct {
@@ -61,9 +67,13 @@ func (m *LexicalMatcher) Find(_ context.Context, query string, elements []types.
 
 	var candidates []scored
 	for _, el := range elements {
+		if shouldExcludeElement(el, constraints.exclusionPhrase) {
+			continue
+		}
+
 		composite := el.Composite()
-		score := lexicalScore(query, composite, el.Interactive, ef)
-		score += positionalBoost(query, el.Positional)
+		score := lexicalScore(searchQuery, composite, el.Interactive, ef)
+		score += positionalBoost(searchQuery, el.Positional)
 		if score > 1.0 {
 			score = 1.0
 		}

--- a/internal/engine/query_negative.go
+++ b/internal/engine/query_negative.go
@@ -1,0 +1,126 @@
+package engine
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/pinchtab/semantic/internal/types"
+)
+
+var negativeQualifierPattern = regexp.MustCompile(`(?i)\b(not|excluding|except)\b`)
+
+type queryNegativeConstraints struct {
+	baseQuery       string
+	exclusionPhrase string
+}
+
+func parseNegativeConstraints(query string) queryNegativeConstraints {
+	cleaned := strings.TrimSpace(query)
+	if cleaned == "" {
+		return queryNegativeConstraints{}
+	}
+
+	loc := negativeQualifierPattern.FindStringIndex(cleaned)
+	if loc == nil {
+		return queryNegativeConstraints{baseQuery: cleaned}
+	}
+
+	base := strings.Trim(strings.TrimSpace(cleaned[:loc[0]]), ",.;:-")
+	remainder := strings.TrimSpace(cleaned[loc[1]:])
+	if base == "" || remainder == "" {
+		return queryNegativeConstraints{baseQuery: cleaned}
+	}
+
+	exclusion := normalizeExclusionPhrase(remainder)
+	if exclusion == "" {
+		return queryNegativeConstraints{baseQuery: cleaned}
+	}
+
+	return queryNegativeConstraints{baseQuery: base, exclusionPhrase: exclusion}
+}
+
+func normalizeExclusionPhrase(s string) string {
+	words := strings.Fields(strings.ToLower(strings.TrimSpace(strings.Trim(s, ",.;:-"))))
+	if len(words) == 0 {
+		return ""
+	}
+
+	for len(words) > 0 && exclusionFillerWords[words[0]] {
+		words = words[1:]
+	}
+	for len(words) > 0 && exclusionTailWords[words[len(words)-1]] {
+		words = words[:len(words)-1]
+	}
+
+	if len(words) == 0 {
+		return ""
+	}
+	return strings.Join(words, " ")
+}
+
+func shouldExcludeElement(el types.ElementDescriptor, exclusion string) bool {
+	if exclusion == "" {
+		return false
+	}
+
+	context := strings.ToLower(strings.Join([]string{
+		el.Parent,
+		el.Section,
+		el.Role,
+		el.Name,
+		el.Value,
+		el.Positional.LabelledBy,
+	}, " "))
+	if context == "" {
+		return false
+	}
+
+	exclusion = strings.ToLower(strings.TrimSpace(exclusion))
+	if exclusion == "" {
+		return false
+	}
+
+	if strings.Contains(context, exclusion) {
+		return true
+	}
+
+	exSet := tokenSet(tokenize(exclusion))
+	if len(exSet) == 0 {
+		return false
+	}
+	ctxSet := tokenSet(tokenize(context))
+
+	matched := 0
+	for tok := range exSet {
+		if ctxSet[tok] {
+			matched++
+		}
+	}
+	if matched == 0 {
+		return false
+	}
+
+	if float64(matched)/float64(len(exSet)) >= 0.5 {
+		return true
+	}
+
+	return lexicalScore(exclusion, context, false, nil) >= 0.55
+}
+
+var exclusionFillerWords = map[string]bool{
+	"in":     true,
+	"on":     true,
+	"at":     true,
+	"of":     true,
+	"to":     true,
+	"from":   true,
+	"inside": true,
+	"within": true,
+	"the":    true,
+	"a":      true,
+	"an":     true,
+}
+
+var exclusionTailWords = map[string]bool{
+	"one": true,
+}

--- a/internal/engine/query_negative_test.go
+++ b/internal/engine/query_negative_test.go
@@ -1,0 +1,156 @@
+package engine
+
+import (
+	"context"
+	"testing"
+
+	"github.com/pinchtab/semantic/internal/types"
+)
+
+func TestParseNegativeConstraints_BasicPatterns(t *testing.T) {
+	tests := []struct {
+		name          string
+		query         string
+		wantBase      string
+		wantExclusion string
+	}{
+		{
+			name:          "not in",
+			query:         "submit button not in header",
+			wantBase:      "submit button",
+			wantExclusion: "header",
+		},
+		{
+			name:          "comma not the one",
+			query:         "login link, not the footer one",
+			wantBase:      "login link",
+			wantExclusion: "footer",
+		},
+		{
+			name:          "excluding",
+			query:         "search box excluding sidebar",
+			wantBase:      "search box",
+			wantExclusion: "sidebar",
+		},
+		{
+			name:          "except",
+			query:         "menu item except sticky footer",
+			wantBase:      "menu item",
+			wantExclusion: "sticky footer",
+		},
+		{
+			name:          "no negative qualifier",
+			query:         "plain submit button",
+			wantBase:      "plain submit button",
+			wantExclusion: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseNegativeConstraints(tt.query)
+			if got.baseQuery != tt.wantBase {
+				t.Fatalf("base query mismatch: want=%q got=%q", tt.wantBase, got.baseQuery)
+			}
+			if got.exclusionPhrase != tt.wantExclusion {
+				t.Fatalf("exclusion mismatch: want=%q got=%q", tt.wantExclusion, got.exclusionPhrase)
+			}
+		})
+	}
+}
+
+func TestShouldExcludeElement_ContextSignals(t *testing.T) {
+	el := types.ElementDescriptor{
+		Ref:     "e1",
+		Role:    "button",
+		Name:    "Submit",
+		Parent:  "Account Header",
+		Section: "Top Header Actions",
+		Positional: types.PositionalHints{
+			LabelledBy: "Header controls",
+		},
+	}
+
+	if !shouldExcludeElement(el, "header") {
+		t.Fatalf("expected header exclusion to match")
+	}
+	if !shouldExcludeElement(el, "top header") {
+		t.Fatalf("expected multi-token exclusion to match")
+	}
+	if shouldExcludeElement(el, "sidebar") {
+		t.Fatalf("did not expect unrelated exclusion to match")
+	}
+}
+
+func TestLexicalMatcher_NegativeQualifierFiltersExcludedSection(t *testing.T) {
+	m := NewLexicalMatcher()
+	elements := []types.ElementDescriptor{
+		{Ref: "header-submit", Role: "button", Name: "Submit", Section: "Header"},
+		{Ref: "main-submit", Role: "button", Name: "Submit", Section: "Checkout content"},
+		{Ref: "footer-submit", Role: "button", Name: "Submit", Section: "Footer"},
+	}
+
+	res, err := m.Find(context.Background(), "submit button not in header", elements, types.FindOptions{Threshold: 0, TopK: 3})
+	if err != nil {
+		t.Fatalf("Find failed: %v", err)
+	}
+	if len(res.Matches) == 0 {
+		t.Fatalf("expected at least one match")
+	}
+	for _, match := range res.Matches {
+		if match.Ref == "header-submit" {
+			t.Fatalf("expected excluded header element to be filtered out")
+		}
+	}
+}
+
+func TestEmbeddingMatcher_NegativeQualifierFiltersSidebarVariant(t *testing.T) {
+	m := NewEmbeddingMatcher(NewHashingEmbedder(128))
+	elements := []types.ElementDescriptor{
+		{Ref: "main-search", Role: "searchbox", Name: "Search", Section: "Main content"},
+		{Ref: "sidebar-search", Role: "searchbox", Name: "Search", Section: "Sidebar"},
+		{Ref: "header-search", Role: "searchbox", Name: "Search", Section: "Header"},
+	}
+
+	res, err := m.Find(context.Background(), "search box excluding sidebar", elements, types.FindOptions{Threshold: 0, TopK: 3})
+	if err != nil {
+		t.Fatalf("Find failed: %v", err)
+	}
+	for _, match := range res.Matches {
+		if match.Ref == "sidebar-search" {
+			t.Fatalf("expected excluded sidebar element to be filtered out")
+		}
+	}
+}
+
+func TestCombinedMatcher_NegativeQualifier_RealWorldDuplicateLinks(t *testing.T) {
+	m := NewCombinedMatcher(NewHashingEmbedder(128))
+	elements := []types.ElementDescriptor{
+		{Ref: "login-header", Role: "link", Name: "Log in", Section: "Header"},
+		{Ref: "login-footer", Role: "link", Name: "Log in", Section: "Footer"},
+		{Ref: "login-sidebar", Role: "link", Name: "Log in", Section: "Sticky Sidebar Quick Actions"},
+	}
+
+	res, err := m.Find(context.Background(), "login link, not the footer one", elements, types.FindOptions{Threshold: 0, TopK: 3})
+	if err != nil {
+		t.Fatalf("Find failed: %v", err)
+	}
+	if len(res.Matches) == 0 {
+		t.Fatalf("expected at least one match")
+	}
+	for _, match := range res.Matches {
+		if match.Ref == "login-footer" {
+			t.Fatalf("expected excluded footer variant to be filtered out")
+		}
+	}
+
+	res2, err := m.Find(context.Background(), "login link except sticky sidebar quick actions", elements, types.FindOptions{Threshold: 0, TopK: 3})
+	if err != nil {
+		t.Fatalf("Find failed: %v", err)
+	}
+	for _, match := range res2.Matches {
+		if match.Ref == "login-sidebar" {
+			t.Fatalf("expected multi-token excluded sidebar variant to be filtered out")
+		}
+	}
+}


### PR DESCRIPTION
## Summary
Implements issue #24 by adding support for negative qualifiers in matching queries.

### What changed
- Added shared negative-query parsing for `not`, `excluding`, and `except`.
- Added exclusion-context matching against element metadata (`section`, `parent`, `name`, `role`, `value`, `labelled_by`).
- Wired exclusion filtering into lexical and embedding matchers (combined inherits this behavior automatically).
- Added focused and edge-case tests, including duplicate-label disambiguation scenarios.
- Added docs/examples in README and CLI reference.

### Example queries now supported
- `submit button not in header`
- `login link, not the footer one`
- `search box excluding sidebar`

## Validation
- `go test ./internal/engine -run "TestParseNegativeConstraints_BasicPatterns|TestShouldExcludeElement_ContextSignals|TestLexicalMatcher_NegativeQualifierFiltersExcludedSection|TestEmbeddingMatcher_NegativeQualifierFiltersSidebarVariant|TestCombinedMatcher_NegativeQualifier_RealWorldDuplicateLinks" -count=1`
- `go test ./internal/engine -run "TestComprehensiveEvaluation|TestMultiSiteEvaluation" -count=1 -v`
- `go test -count=1 ./...`
- `go vet ./...`
- `go build ./...`
- `go build -o semantic.exe ./cmd/semantic`
- `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.9.0 run`
- Manual CLI checks with duplicate section variants (header/footer/sidebar)

## Environment note
- Local Windows race run (`go test -race ./...`) is blocked by local 64-bit cgo toolchain availability (`cc1.exe ... 64-bit mode not compiled in`).
- CI runs on Ubuntu and will execute race tests there.

Closes #24
