### PR TITLE
feat: support ordinal queries (first/second/last)

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ Implementations are internal — consumers use the `ElementMatcher` interface an
 ## Features
 
 - **Synonym expansion** — 54 UI synonym groups ("sign in" ↔ "log in", "cart" ↔ "basket", "preferences" ↔ "settings", etc.)
+- **Ordinal selection** — Positional intent like `first`, `second`, `3rd`, and `last` for duplicate element sets
 - **Confidence calibration** — Scores mapped to high (≥ 0.8) / medium (≥ 0.6) / low labels
 - **Error classification** — Classify browser errors (CDP, chromedp) as recoverable or not
 - **Self-healing recovery** — Re-locate stale elements after DOM changes via callback interfaces
@@ -183,6 +184,10 @@ curl -s localhost:9999/snapshot | semantic find "search box"
 semantic find "login" --snapshot page.json --format json    # machine-readable
 semantic find "login" --snapshot page.json --format table   # human-readable
 semantic find "login" --snapshot page.json --format refs    # just refs
+
+# Select by order among duplicate matches
+semantic find "second button" --snapshot page.json
+semantic find "last input field" --snapshot page.json
 
 # Score a specific element
 semantic match "login" e4 --snapshot page.json

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -33,6 +33,11 @@ semantic find "login" --snapshot page.json --format json
 
 # Just refs (for piping)
 semantic find "submit" --snapshot page.json --format refs
+
+# Ordinal selection for repeated element types
+semantic find "second button" --snapshot page.json
+semantic find "third menu item" --snapshot page.json
+semantic find "last input field" --snapshot page.json
 ```
 
 ### `semantic match`

--- a/internal/engine/combined.go
+++ b/internal/engine/combined.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"github.com/pinchtab/semantic/internal/types"
+	"math"
 	"sort"
 )
 
@@ -44,14 +45,26 @@ func (c *CombinedMatcher) Find(ctx context.Context, query string, elements []typ
 		opts.TopK = 3
 	}
 
+	ordinal := parseOrdinalConstraint(query)
+	effectiveQuery := query
+	if ordinal.baseQuery != "" {
+		effectiveQuery = ordinal.baseQuery
+	}
+
+	mergeOpts := opts
+	if ordinal.hasOrdinal {
+		mergeOpts.TopK = len(elements)
+	}
+
 	lexW, embW := c.weights(opts)
 
-	lexResult, embResult, err := c.runBoth(ctx, query, elements, opts)
+	lexResult, embResult, err := c.runBoth(ctx, effectiveQuery, elements, opts)
 	if err != nil {
 		return types.FindResult{}, err
 	}
 
-	return c.mergeResults(lexResult, embResult, elements, opts, lexW, embW), nil
+	merged := c.mergeResults(lexResult, embResult, elements, mergeOpts, lexW, embW)
+	return selectOrdinalMatchInOrder(merged, ordinal, elements), nil
 }
 
 func (c *CombinedMatcher) weights(opts types.FindOptions) (float64, float64) {
@@ -146,7 +159,18 @@ func (c *CombinedMatcher) mergeResults(lexResult, embResult types.FindResult, el
 	}
 
 	sort.Slice(candidates, func(i, j int) bool {
-		return candidates[i].score > candidates[j].score
+		scoreDiff := candidates[i].score - candidates[j].score
+		if math.Abs(scoreDiff) > 1e-9 {
+			return scoreDiff > 0
+		}
+
+		idxI := candidates[i].el.Positional.SiblingIndex
+		idxJ := candidates[j].el.Positional.SiblingIndex
+		if idxI != idxJ {
+			return idxI < idxJ
+		}
+
+		return candidates[i].ref < candidates[j].ref
 	})
 	if len(candidates) > opts.TopK {
 		candidates = candidates[:opts.TopK]

--- a/internal/engine/query_ordinal.go
+++ b/internal/engine/query_ordinal.go
@@ -1,0 +1,193 @@
+package engine
+
+import (
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/pinchtab/semantic/internal/types"
+)
+
+type ordinalConstraint struct {
+	hasOrdinal bool
+	last       bool
+	position   int
+	baseQuery  string
+}
+
+var numericOrdinalPattern = regexp.MustCompile(`^(\d+)(st|nd|rd|th)$`)
+
+var ordinalWords = map[string]int{
+	"first":   1,
+	"second":  2,
+	"third":   3,
+	"fourth":  4,
+	"fifth":   5,
+	"sixth":   6,
+	"seventh": 7,
+	"eighth":  8,
+	"ninth":   9,
+	"tenth":   10,
+}
+
+var ordinalTargetWords = map[string]bool{
+	"button":    true,
+	"link":      true,
+	"input":     true,
+	"field":     true,
+	"textbox":   true,
+	"searchbox": true,
+	"item":      true,
+	"menu":      true,
+	"option":    true,
+	"tab":       true,
+	"result":    true,
+	"row":       true,
+	"column":    true,
+	"card":      true,
+	"entry":     true,
+	"element":   true,
+}
+
+func parseOrdinalConstraint(query string) ordinalConstraint {
+	cleaned := strings.TrimSpace(query)
+	if cleaned == "" {
+		return ordinalConstraint{}
+	}
+
+	words := strings.Fields(cleaned)
+	if len(words) == 0 {
+		return ordinalConstraint{}
+	}
+
+	ordIdx := -1
+	ordPos := 0
+	ordLast := false
+
+	for i, w := range words {
+		norm := normalizeQueryToken(w)
+		if norm == "" {
+			continue
+		}
+
+		if norm == "last" || norm == "final" {
+			ordIdx = i
+			ordLast = true
+			break
+		}
+
+		if pos, ok := ordinalWords[norm]; ok {
+			ordIdx = i
+			ordPos = pos
+			break
+		}
+
+		if pos, ok := parseNumericOrdinal(norm); ok {
+			ordIdx = i
+			ordPos = pos
+			break
+		}
+	}
+
+	if ordIdx == -1 {
+		return ordinalConstraint{baseQuery: cleaned}
+	}
+
+	if !containsOrdinalTarget(words, ordIdx) {
+		return ordinalConstraint{baseQuery: cleaned}
+	}
+
+	filtered := make([]string, 0, len(words)-1)
+	for i, w := range words {
+		if i == ordIdx {
+			continue
+		}
+		filtered = append(filtered, w)
+	}
+
+	base := strings.Trim(strings.TrimSpace(strings.Join(filtered, " ")), ",.;:-")
+	if base == "" {
+		base = cleaned
+	}
+
+	return ordinalConstraint{
+		hasOrdinal: true,
+		last:       ordLast,
+		position:   ordPos,
+		baseQuery:  base,
+	}
+}
+
+func parseNumericOrdinal(token string) (int, bool) {
+	m := numericOrdinalPattern.FindStringSubmatch(token)
+	if len(m) != 3 {
+		return 0, false
+	}
+	n, err := strconv.Atoi(m[1])
+	if err != nil || n <= 0 {
+		return 0, false
+	}
+	return n, true
+}
+
+func normalizeQueryToken(token string) string {
+	return strings.Trim(strings.ToLower(token), ",.;:-")
+}
+
+func containsOrdinalTarget(words []string, ordIdx int) bool {
+	for i, w := range words {
+		if i == ordIdx {
+			continue
+		}
+		if ordinalTargetWords[normalizeQueryToken(w)] {
+			return true
+		}
+	}
+	return false
+}
+
+func selectOrdinalMatchInOrder(result types.FindResult, constraint ordinalConstraint, elements []types.ElementDescriptor) types.FindResult {
+	if !constraint.hasOrdinal || len(result.Matches) == 0 {
+		return result
+	}
+
+	refOrder := make(map[string]int, len(elements))
+	for idx, el := range elements {
+		refOrder[el.Ref] = idx
+	}
+
+	ordered := make([]types.ElementMatch, len(result.Matches))
+	copy(ordered, result.Matches)
+	sort.SliceStable(ordered, func(i, j int) bool {
+		idxI, okI := refOrder[ordered[i].Ref]
+		idxJ, okJ := refOrder[ordered[j].Ref]
+		if okI && okJ {
+			return idxI < idxJ
+		}
+		if okI != okJ {
+			return okI
+		}
+		return ordered[i].Ref < ordered[j].Ref
+	})
+
+	idx := -1
+	if constraint.last {
+		idx = len(ordered) - 1
+	} else if constraint.position > 0 {
+		idx = constraint.position - 1
+	}
+
+	if idx < 0 || idx >= len(ordered) {
+		result.Matches = nil
+		result.BestRef = ""
+		result.BestScore = 0
+		return result
+	}
+
+	chosen := ordered[idx]
+	result.Matches = []types.ElementMatch{chosen}
+	result.BestRef = chosen.Ref
+	result.BestScore = chosen.Score
+	return result
+}

--- a/internal/engine/query_ordinal_test.go
+++ b/internal/engine/query_ordinal_test.go
@@ -1,0 +1,144 @@
+package engine
+
+import (
+	"context"
+	"testing"
+
+	"github.com/pinchtab/semantic/internal/types"
+)
+
+func TestParseOrdinalConstraint_BasicPatterns(t *testing.T) {
+	tests := []struct {
+		name       string
+		query      string
+		wantBase   string
+		wantHasOrd bool
+		wantPos    int
+		wantIsLast bool
+	}{
+		{
+			name:       "second button",
+			query:      "second button",
+			wantBase:   "button",
+			wantHasOrd: true,
+			wantPos:    2,
+		},
+		{
+			name:       "numeric ordinal",
+			query:      "3rd menu item",
+			wantBase:   "menu item",
+			wantHasOrd: true,
+			wantPos:    3,
+		},
+		{
+			name:       "last input field",
+			query:      "last input field",
+			wantBase:   "input field",
+			wantHasOrd: true,
+			wantIsLast: true,
+		},
+		{
+			name:       "non-ordinal content query",
+			query:      "first name",
+			wantBase:   "first name",
+			wantHasOrd: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseOrdinalConstraint(tt.query)
+			if got.baseQuery != tt.wantBase {
+				t.Fatalf("base query mismatch: want=%q got=%q", tt.wantBase, got.baseQuery)
+			}
+			if got.hasOrdinal != tt.wantHasOrd {
+				t.Fatalf("hasOrdinal mismatch: want=%v got=%v", tt.wantHasOrd, got.hasOrdinal)
+			}
+			if got.position != tt.wantPos {
+				t.Fatalf("position mismatch: want=%d got=%d", tt.wantPos, got.position)
+			}
+			if got.last != tt.wantIsLast {
+				t.Fatalf("last mismatch: want=%v got=%v", tt.wantIsLast, got.last)
+			}
+		})
+	}
+}
+
+func TestCombinedMatcher_OrdinalQuery_SecondButton(t *testing.T) {
+	m := NewCombinedMatcher(NewHashingEmbedder(128))
+	elements := []types.ElementDescriptor{
+		{Ref: "btn-1", Role: "button", Name: "Action", Positional: types.PositionalHints{SiblingIndex: 0}},
+		{Ref: "btn-2", Role: "button", Name: "Action", Positional: types.PositionalHints{SiblingIndex: 1}},
+		{Ref: "btn-3", Role: "button", Name: "Action", Positional: types.PositionalHints{SiblingIndex: 2}},
+	}
+
+	res, err := m.Find(context.Background(), "second button", elements, types.FindOptions{Threshold: 0, TopK: 3})
+	if err != nil {
+		t.Fatalf("Find failed: %v", err)
+	}
+	if len(res.Matches) != 1 {
+		t.Fatalf("expected one ordinal-selected match, got %d", len(res.Matches))
+	}
+	if res.BestRef != "btn-2" {
+		t.Fatalf("expected second button btn-2, got %s", res.BestRef)
+	}
+}
+
+func TestCombinedMatcher_OrdinalQuery_LastInputField(t *testing.T) {
+	m := NewCombinedMatcher(NewHashingEmbedder(128))
+	elements := []types.ElementDescriptor{
+		{Ref: "input-1", Role: "textbox", Name: "Email", Positional: types.PositionalHints{SiblingIndex: 0}},
+		{Ref: "input-2", Role: "textbox", Name: "Email", Positional: types.PositionalHints{SiblingIndex: 1}},
+		{Ref: "input-3", Role: "textbox", Name: "Email", Positional: types.PositionalHints{SiblingIndex: 2}},
+	}
+
+	res, err := m.Find(context.Background(), "last input field", elements, types.FindOptions{Threshold: 0, TopK: 3})
+	if err != nil {
+		t.Fatalf("Find failed: %v", err)
+	}
+	if len(res.Matches) != 1 {
+		t.Fatalf("expected one ordinal-selected match, got %d", len(res.Matches))
+	}
+	if res.BestRef != "input-3" {
+		t.Fatalf("expected last input field input-3, got %s", res.BestRef)
+	}
+}
+
+func TestCombinedMatcher_OrdinalQuery_OutOfRangeReturnsNoMatch(t *testing.T) {
+	m := NewCombinedMatcher(NewHashingEmbedder(128))
+	elements := []types.ElementDescriptor{
+		{Ref: "b1", Role: "button", Name: "Continue", Positional: types.PositionalHints{SiblingIndex: 0}},
+		{Ref: "b2", Role: "button", Name: "Continue", Positional: types.PositionalHints{SiblingIndex: 1}},
+		{Ref: "b3", Role: "button", Name: "Continue", Positional: types.PositionalHints{SiblingIndex: 2}},
+	}
+
+	res, err := m.Find(context.Background(), "fifth button", elements, types.FindOptions{Threshold: 0, TopK: 3})
+	if err != nil {
+		t.Fatalf("Find failed: %v", err)
+	}
+	if len(res.Matches) != 0 {
+		t.Fatalf("expected no matches for out-of-range ordinal, got %d", len(res.Matches))
+	}
+	if res.BestRef != "" || res.BestScore != 0 {
+		t.Fatalf("expected empty best match for out-of-range ordinal, got ref=%q score=%f", res.BestRef, res.BestScore)
+	}
+}
+
+func TestCombinedMatcher_OrdinalGuard_DoesNotTreatFirstNameAsOrdinal(t *testing.T) {
+	m := NewCombinedMatcher(NewHashingEmbedder(128))
+	elements := []types.ElementDescriptor{
+		{Ref: "first-name", Role: "textbox", Name: "First Name", Positional: types.PositionalHints{SiblingIndex: 3}},
+		{Ref: "last-name", Role: "textbox", Name: "Last Name", Positional: types.PositionalHints{SiblingIndex: 0}},
+	}
+
+	res, err := m.Find(context.Background(), "first name", elements, types.FindOptions{Threshold: 0, TopK: 2})
+	if err != nil {
+		t.Fatalf("Find failed: %v", err)
+	}
+	if len(res.Matches) == 0 {
+		t.Fatalf("expected at least one match")
+	}
+	if res.BestRef != "first-name" {
+		t.Fatalf("expected semantic match for 'first name', got %s", res.BestRef)
+	}
+}


### PR DESCRIPTION
## Summary
Implements issue #25 by supporting ordinal queries to select an element by position among matching candidates.

### What changed
- Added ordinal query parsing for `first`, `second`, `third`, numeric ordinals (`1st`, `2nd`, `3rd`, ...), and `last`.
- Added guard logic to avoid false positives for semantic phrases (for example, `first name`).
- Added deterministic tie-breaking in combined matcher.
- Added ordinal selection in document order after matching.
- Added parser and integration tests for normal, edge, and out-of-range ordinal cases.
- Added docs/examples in README and CLI reference.

### Example queries now supported
- `second button`
- `third menu item`
- `last input field`

## Validation
- `go test ./internal/engine -run "TestParseOrdinalConstraint_BasicPatterns|TestCombinedMatcher_OrdinalQuery_SecondButton|TestCombinedMatcher_OrdinalQuery_LastInputField|TestCombinedMatcher_OrdinalQuery_OutOfRangeReturnsNoMatch|TestCombinedMatcher_OrdinalGuard_DoesNotTreatFirstNameAsOrdinal" -count=1`
- `go test -count=1 ./...`
- `go vet ./...`
- `go build ./...`
- `go build -o semantic.exe ./cmd/semantic`
- `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.9.0 run`
- Manual CLI checks with duplicated controls:
  - `second button` -> second result by order
  - `last input field` -> last result by order
  - `fifth button` (out-of-range) -> no result

## Environment note
- Local Windows race run (`go test -race ./...`) is blocked by local 64-bit cgo toolchain availability (`cc1.exe ... 64-bit mode not compiled in`).
- CI runs on Ubuntu and will execute race tests there.

Closes #25
