### PR TITLE
hardening: normalize fusion weights and bound combined scores

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ Implementations are internal — consumers use the `ElementMatcher` interface an
 ## Features
 
 - **Synonym expansion** — 54 UI synonym groups ("sign in" ↔ "log in", "cart" ↔ "basket", "preferences" ↔ "settings", etc.)
+- **Visual position hints** — Understand layout cues like `top`, `bottom`, `left`, `right`, and `above`/`below` anchors
 - **Confidence calibration** — Scores mapped to high (≥ 0.8) / medium (≥ 0.6) / low labels
 - **Error classification** — Classify browser errors (CDP, chromedp) as recoverable or not
 - **Self-healing recovery** — Re-locate stale elements after DOM changes via callback interfaces
@@ -183,6 +184,11 @@ curl -s localhost:9999/snapshot | semantic find "search box"
 semantic find "login" --snapshot page.json --format json    # machine-readable
 semantic find "login" --snapshot page.json --format table   # human-readable
 semantic find "login" --snapshot page.json --format refs    # just refs
+
+# Visual position hints
+semantic find "button in top right corner" --snapshot page.json
+semantic find "link below the search box" --snapshot page.json
+semantic find "sidebar on the left" --snapshot page.json
 
 # Score a specific element
 semantic match "login" e4 --snapshot page.json

--- a/cmd/semantic/main.go
+++ b/cmd/semantic/main.go
@@ -62,10 +62,16 @@ Flags (find/match):
 
 // snapshotElement is the JSON shape from pinchtab's /snapshot endpoint.
 type snapshotPositional struct {
-	Depth        int    `json:"depth"`
-	SiblingIndex int    `json:"sibling_index"`
-	SiblingCount int    `json:"sibling_count"`
-	LabelledBy   string `json:"labelled_by"`
+	Depth        int     `json:"depth"`
+	SiblingIndex int     `json:"sibling_index"`
+	SiblingCount int     `json:"sibling_count"`
+	LabelledBy   string  `json:"labelled_by"`
+	X            float64 `json:"x"`
+	Y            float64 `json:"y"`
+	Top          float64 `json:"top"`
+	Left         float64 `json:"left"`
+	Width        float64 `json:"width"`
+	Height       float64 `json:"height"`
 }
 
 type snapshotElement struct {
@@ -80,6 +86,12 @@ type snapshotElement struct {
 	SiblingIdx  int                 `json:"sibling_index"`
 	SiblingCnt  int                 `json:"sibling_count"`
 	LabelledBy  string              `json:"labelled_by"`
+	X           float64             `json:"x"`
+	Y           float64             `json:"y"`
+	Top         float64             `json:"top"`
+	Left        float64             `json:"left"`
+	Width       float64             `json:"width"`
+	Height      float64             `json:"height"`
 	Positional  *snapshotPositional `json:"positional"`
 }
 
@@ -112,6 +124,16 @@ func loadSnapshot(path string) ([]semantic.ElementDescriptor, error) {
 		depth := e.Depth
 		siblingIdx := e.SiblingIdx
 		siblingCnt := e.SiblingCnt
+		x := e.X
+		y := e.Y
+		if x == 0 && e.Left != 0 {
+			x = e.Left
+		}
+		if y == 0 && e.Top != 0 {
+			y = e.Top
+		}
+		width := e.Width
+		height := e.Height
 		if e.Positional != nil {
 			if e.Positional.Depth != 0 {
 				depth = e.Positional.Depth
@@ -124,6 +146,23 @@ func loadSnapshot(path string) ([]semantic.ElementDescriptor, error) {
 			}
 			if e.Positional.LabelledBy != "" {
 				labelledBy = e.Positional.LabelledBy
+			}
+
+			hasHorizontal := e.Positional.X != 0 || e.Positional.Left != 0 || e.Positional.Width > 0
+			hasVertical := e.Positional.Y != 0 || e.Positional.Top != 0 || e.Positional.Height > 0
+			if hasHorizontal {
+				x = e.Positional.X
+				if x == 0 && e.Positional.Left != 0 {
+					x = e.Positional.Left
+				}
+				width = e.Positional.Width
+			}
+			if hasVertical {
+				y = e.Positional.Y
+				if y == 0 && e.Positional.Top != 0 {
+					y = e.Positional.Top
+				}
+				height = e.Positional.Height
 			}
 		}
 
@@ -140,6 +179,10 @@ func loadSnapshot(path string) ([]semantic.ElementDescriptor, error) {
 				SiblingIndex: siblingIdx,
 				SiblingCount: siblingCnt,
 				LabelledBy:   labelledBy,
+				X:            x,
+				Y:            y,
+				Width:        width,
+				Height:       height,
 			},
 		}
 	}

--- a/cmd/semantic/main_test.go
+++ b/cmd/semantic/main_test.go
@@ -12,8 +12,8 @@ func TestLoadSnapshot_PropagatesInteractiveFlag(t *testing.T) {
 	}
 
 	json := `[
-		{"ref":"e1","role":"button","name":"Submit","interactive":true,"parent":"Login form","section":"Authentication","depth":3,"sibling_index":1,"sibling_count":2,"labelled_by":"Primary Action"},
-		{"ref":"e2","role":"text","name":"Submit","interactive":false,"parent":"Payment form","section":"Checkout","positional":{"depth":2,"sibling_index":0,"sibling_count":1,"labelled_by":"Secondary Action"}}
+		{"ref":"e1","role":"button","name":"Submit","interactive":true,"parent":"Login form","section":"Authentication","depth":3,"sibling_index":1,"sibling_count":2,"labelled_by":"Primary Action","x":20,"y":40,"width":120,"height":30},
+		{"ref":"e2","role":"text","name":"Submit","interactive":false,"parent":"Payment form","section":"Checkout","positional":{"depth":2,"sibling_index":0,"sibling_count":1,"labelled_by":"Secondary Action","left":300,"top":640,"width":200,"height":44}}
 	]`
 	if _, err := f.WriteString(json); err != nil {
 		t.Fatalf("WriteString failed: %v", err)
@@ -50,6 +50,12 @@ func TestLoadSnapshot_PropagatesInteractiveFlag(t *testing.T) {
 	if descs[0].Positional.LabelledBy != "Primary Action" {
 		t.Fatalf("expected first descriptor labelled_by=Primary Action, got %q", descs[0].Positional.LabelledBy)
 	}
+	if descs[0].Positional.X != 20 || descs[0].Positional.Y != 40 {
+		t.Fatalf("expected first descriptor x/y=20/40, got %f/%f", descs[0].Positional.X, descs[0].Positional.Y)
+	}
+	if descs[0].Positional.Width != 120 || descs[0].Positional.Height != 30 {
+		t.Fatalf("expected first descriptor width/height=120/30, got %f/%f", descs[0].Positional.Width, descs[0].Positional.Height)
+	}
 	if descs[1].Interactive {
 		t.Fatalf("expected second descriptor interactive=false")
 	}
@@ -70,5 +76,11 @@ func TestLoadSnapshot_PropagatesInteractiveFlag(t *testing.T) {
 	}
 	if descs[1].Positional.LabelledBy != "Secondary Action" {
 		t.Fatalf("expected second descriptor labelled_by=Secondary Action, got %q", descs[1].Positional.LabelledBy)
+	}
+	if descs[1].Positional.X != 300 || descs[1].Positional.Y != 640 {
+		t.Fatalf("expected second descriptor x/y=300/640, got %f/%f", descs[1].Positional.X, descs[1].Positional.Y)
+	}
+	if descs[1].Positional.Width != 200 || descs[1].Positional.Height != 44 {
+		t.Fatalf("expected second descriptor width/height=200/44, got %f/%f", descs[1].Positional.Width, descs[1].Positional.Height)
 	}
 }

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -33,6 +33,11 @@ semantic find "login" --snapshot page.json --format json
 
 # Just refs (for piping)
 semantic find "submit" --snapshot page.json --format refs
+
+# Visual layout hints
+semantic find "button in top right corner" --snapshot page.json
+semantic find "link below the search box" --snapshot page.json
+semantic find "sidebar on the left" --snapshot page.json
 ```
 
 ### `semantic match`

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -86,8 +86,34 @@ The CLI expects a JSON array of element descriptors:
 
 ```json
 [
-  {"ref": "e0", "role": "button", "name": "Sign In"},
-  {"ref": "e1", "role": "textbox", "name": "Email"},
-  {"ref": "e2", "role": "link", "name": "Forgot Password"}
+  {
+    "ref": "e0",
+    "role": "button",
+    "name": "Sign In",
+    "interactive": true,
+    "parent": "Auth card",
+    "section": "Header",
+    "x": 920,
+    "y": 16,
+    "width": 96,
+    "height": 32
+  },
+  {
+    "ref": "e1",
+    "role": "textbox",
+    "name": "Email",
+    "positional": {
+      "depth": 3,
+      "sibling_index": 1,
+      "sibling_count": 2,
+      "labelled_by": "Email",
+      "left": 120,
+      "top": 240,
+      "width": 320,
+      "height": 36
+    }
+  }
 ]
 ```
+
+Top-level geometry (`x`, `y`, `top`, `left`, `width`, `height`) and nested `positional` fields are both supported. Supplying coordinates improves results for visual hints such as `top right`, `below`, and `left`.

--- a/internal/engine/combined.go
+++ b/internal/engine/combined.go
@@ -4,7 +4,13 @@ import (
 	"context"
 	"fmt"
 	"github.com/pinchtab/semantic/internal/types"
+	"math"
 	"sort"
+)
+
+const (
+	defaultCombinedLexicalWeight   = 0.6
+	defaultCombinedEmbeddingWeight = 0.4
 )
 
 // combinedMatcher fuses lexical and embedding scores:
@@ -30,8 +36,8 @@ func NewCombinedMatcher(embedder Embedder) *CombinedMatcher {
 	return &CombinedMatcher{
 		lexical:         NewLexicalMatcher(),
 		embedding:       NewEmbeddingMatcher(embedder),
-		LexicalWeight:   0.6,
-		EmbeddingWeight: 0.4,
+		LexicalWeight:   defaultCombinedLexicalWeight,
+		EmbeddingWeight: defaultCombinedEmbeddingWeight,
 	}
 }
 
@@ -40,9 +46,11 @@ func (c *CombinedMatcher) Strategy() string {
 }
 
 func (c *CombinedMatcher) Find(ctx context.Context, query string, elements []types.ElementDescriptor, opts types.FindOptions) (types.FindResult, error) {
-	if opts.TopK <= 0 {
-		opts.TopK = 3
+	if ctx == nil {
+		ctx = context.Background()
 	}
+
+	opts = sanitizeFindOptions(opts, len(elements), 3)
 
 	visualHints := parseVisualQueryHints(query)
 	effectiveQuery := query
@@ -67,10 +75,49 @@ func (c *CombinedMatcher) Find(ctx context.Context, query string, elements []typ
 }
 
 func (c *CombinedMatcher) weights(opts types.FindOptions) (float64, float64) {
-	if opts.LexicalWeight > 0 || opts.EmbeddingWeight > 0 {
-		return opts.LexicalWeight, opts.EmbeddingWeight
+	baseLex, baseEmb := normalizeWeights(c.LexicalWeight, c.EmbeddingWeight)
+	if baseLex == 0 && baseEmb == 0 {
+		baseLex, baseEmb = defaultCombinedLexicalWeight, defaultCombinedEmbeddingWeight
 	}
-	return c.LexicalWeight, c.EmbeddingWeight
+
+	reqLex := sanitizeWeight(opts.LexicalWeight)
+	reqEmb := sanitizeWeight(opts.EmbeddingWeight)
+	if reqLex == 0 && reqEmb == 0 {
+		return baseLex, baseEmb
+	}
+
+	if reqLex > 0 && reqEmb == 0 && reqLex <= 1 {
+		reqEmb = 1 - reqLex
+	}
+	if reqEmb > 0 && reqLex == 0 && reqEmb <= 1 {
+		reqLex = 1 - reqEmb
+	}
+
+	lex, emb := normalizeWeights(reqLex, reqEmb)
+	if lex == 0 && emb == 0 {
+		return baseLex, baseEmb
+	}
+
+	return lex, emb
+}
+
+func sanitizeWeight(weight float64) float64 {
+	if math.IsNaN(weight) || math.IsInf(weight, 0) || weight < 0 {
+		return 0
+	}
+	return weight
+}
+
+func normalizeWeights(lexicalWeight, embeddingWeight float64) (float64, float64) {
+	lexicalWeight = sanitizeWeight(lexicalWeight)
+	embeddingWeight = sanitizeWeight(embeddingWeight)
+
+	total := lexicalWeight + embeddingWeight
+	if total <= 0 {
+		return 0, 0
+	}
+
+	return lexicalWeight / total, embeddingWeight / total
 }
 
 type matcherResult struct {
@@ -106,8 +153,19 @@ func (c *CombinedMatcher) runBoth(ctx context.Context, query string, elements []
 		embCh <- matcherResult{r, err}
 	}()
 
-	lexRes := <-lexCh
-	embRes := <-embCh
+	var lexRes, embRes matcherResult
+	gotLex, gotEmb := false, false
+
+	for !gotLex || !gotEmb {
+		select {
+		case <-ctx.Done():
+			return types.FindResult{}, types.FindResult{}, ctx.Err()
+		case lexRes = <-lexCh:
+			gotLex = true
+		case embRes = <-embCh:
+			gotEmb = true
+		}
+	}
 
 	if lexRes.err != nil {
 		return types.FindResult{}, types.FindResult{}, lexRes.err
@@ -148,6 +206,12 @@ func (c *CombinedMatcher) mergeResults(lexResult, embResult types.FindResult, el
 	candidates := make([]scored, 0, len(allRefs))
 	appendCandidate := func(ref string, el types.ElementDescriptor, order int) {
 		combined := lexW*lexScores[ref] + embW*embScores[ref]
+		if combined > 1 {
+			combined = 1
+		}
+		if combined < 0 {
+			combined = 0
+		}
 		if combined < opts.Threshold {
 			return
 		}

--- a/internal/engine/combined.go
+++ b/internal/engine/combined.go
@@ -44,14 +44,26 @@ func (c *CombinedMatcher) Find(ctx context.Context, query string, elements []typ
 		opts.TopK = 3
 	}
 
+	visualHints := parseVisualQueryHints(query)
+	effectiveQuery := query
+	if visualHints.baseQuery != "" {
+		effectiveQuery = visualHints.baseQuery
+	}
+
+	mergeOpts := opts
+	if visualHints.hasHints {
+		mergeOpts.TopK = len(elements)
+	}
+
 	lexW, embW := c.weights(opts)
 
-	lexResult, embResult, err := c.runBoth(ctx, query, elements, opts)
+	lexResult, embResult, err := c.runBoth(ctx, effectiveQuery, elements, opts)
 	if err != nil {
 		return types.FindResult{}, err
 	}
 
-	return c.mergeResults(lexResult, embResult, elements, opts, lexW, embW), nil
+	merged := c.mergeResults(lexResult, embResult, elements, mergeOpts, lexW, embW)
+	return applyVisualHintBoost(merged, visualHints, elements, opts.TopK), nil
 }
 
 func (c *CombinedMatcher) weights(opts types.FindOptions) (float64, float64) {

--- a/internal/engine/combined.go
+++ b/internal/engine/combined.go
@@ -122,6 +122,7 @@ type scored struct {
 	ref      string
 	score    float64
 	el       types.ElementDescriptor
+	order    int
 	lexScore float64
 	embScore float64
 }
@@ -145,20 +146,48 @@ func (c *CombinedMatcher) mergeResults(lexResult, embResult types.FindResult, el
 	}
 
 	candidates := make([]scored, 0, len(allRefs))
-	for ref := range allRefs {
+	appendCandidate := func(ref string, el types.ElementDescriptor, order int) {
 		combined := lexW*lexScores[ref] + embW*embScores[ref]
-		if combined >= opts.Threshold {
-			s := scored{ref: ref, score: combined, el: refToElem[ref]}
-			if opts.Explain {
-				s.lexScore = lexW * lexScores[ref]
-				s.embScore = embW * embScores[ref]
-			}
-			candidates = append(candidates, s)
+		if combined < opts.Threshold {
+			return
+		}
+
+		s := scored{ref: ref, score: combined, el: el, order: order}
+		if opts.Explain {
+			s.lexScore = lexW * lexScores[ref]
+			s.embScore = embW * embScores[ref]
+		}
+		candidates = append(candidates, s)
+	}
+
+	for i, el := range elements {
+		if !allRefs[el.Ref] {
+			continue
+		}
+		appendCandidate(el.Ref, el, i)
+		delete(allRefs, el.Ref)
+	}
+
+	if len(allRefs) > 0 {
+		extraRefs := make([]string, 0, len(allRefs))
+		for ref := range allRefs {
+			extraRefs = append(extraRefs, ref)
+		}
+		sort.Strings(extraRefs)
+		for i, ref := range extraRefs {
+			appendCandidate(ref, refToElem[ref], len(elements)+i)
 		}
 	}
 
 	sort.Slice(candidates, func(i, j int) bool {
-		return candidates[i].score > candidates[j].score
+		return rankedMatchLess(
+			candidates[i].score,
+			candidates[i].el,
+			candidates[i].order,
+			candidates[j].score,
+			candidates[j].el,
+			candidates[j].order,
+		)
 	})
 	if len(candidates) > opts.TopK {
 		candidates = candidates[:opts.TopK]

--- a/internal/engine/combined_test.go
+++ b/internal/engine/combined_test.go
@@ -2,9 +2,12 @@ package engine
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"github.com/pinchtab/semantic/internal/types"
+	"math"
 	"testing"
+	"time"
 )
 
 // CATEGORY 6: Role Boost Accumulation Test (Bug Fix)
@@ -483,4 +486,135 @@ func TestCombinedMatcher_WeightsApplied(t *testing.T) {
 	if result.BestRef != "e0" {
 		t.Errorf("expected BestRef=e0, got %s", result.BestRef)
 	}
+}
+
+func TestCombinedMatcher_Weights_SingleOverrideUsesComplement(t *testing.T) {
+	m := NewCombinedMatcher(NewHashingEmbedder(128))
+
+	lex, emb := m.weights(types.FindOptions{LexicalWeight: 0.85})
+	if math.Abs(lex-0.85) > 1e-9 || math.Abs(emb-0.15) > 1e-9 {
+		t.Fatalf("unexpected single lexical override resolution: got lexical=%.6f embedding=%.6f", lex, emb)
+	}
+
+	lex, emb = m.weights(types.FindOptions{EmbeddingWeight: 0.70})
+	if math.Abs(lex-0.30) > 1e-9 || math.Abs(emb-0.70) > 1e-9 {
+		t.Fatalf("unexpected single embedding override resolution: got lexical=%.6f embedding=%.6f", lex, emb)
+	}
+}
+
+func TestCombinedMatcher_Weights_AdversarialNormalizationGrid(t *testing.T) {
+	m := NewCombinedMatcher(NewHashingEmbedder(128))
+
+	inputs := []float64{
+		-10,
+		-1,
+		-0.25,
+		0,
+		0.001,
+		0.2,
+		0.5,
+		0.9,
+		1,
+		2,
+		10,
+		math.NaN(),
+		math.Inf(1),
+	}
+
+	for _, baseLex := range inputs {
+		for _, baseEmb := range inputs {
+			m.LexicalWeight = baseLex
+			m.EmbeddingWeight = baseEmb
+
+			for _, reqLex := range inputs {
+				for _, reqEmb := range inputs {
+					lex, emb := m.weights(types.FindOptions{LexicalWeight: reqLex, EmbeddingWeight: reqEmb})
+
+					if math.IsNaN(lex) || math.IsNaN(emb) || math.IsInf(lex, 0) || math.IsInf(emb, 0) {
+						t.Fatalf("non-finite weights from base=(%v,%v) req=(%v,%v): lexical=%v embedding=%v", baseLex, baseEmb, reqLex, reqEmb, lex, emb)
+					}
+					if lex < 0 || emb < 0 {
+						t.Fatalf("negative weights from base=(%v,%v) req=(%v,%v): lexical=%v embedding=%v", baseLex, baseEmb, reqLex, reqEmb, lex, emb)
+					}
+
+					sum := lex + emb
+					if math.Abs(sum-1) > 1e-9 {
+						t.Fatalf("weights do not normalize to 1 from base=(%v,%v) req=(%v,%v): lexical=%v embedding=%v sum=%v", baseLex, baseEmb, reqLex, reqEmb, lex, emb, sum)
+					}
+				}
+			}
+		}
+	}
+}
+
+func TestCombinedMatcher_ScoreBoundedUnderInvalidModelWeights(t *testing.T) {
+	m := NewCombinedMatcher(NewHashingEmbedder(128))
+	m.LexicalWeight = 9
+	m.EmbeddingWeight = 9
+
+	elements := []types.ElementDescriptor{
+		{Ref: "e0", Role: "button", Name: "Sign in"},
+		{Ref: "e1", Role: "link", Name: "Register"},
+	}
+
+	result, err := m.Find(context.Background(), "sign in button", elements, types.FindOptions{Threshold: 0, TopK: 2})
+	if err != nil {
+		t.Fatalf("Find returned error: %v", err)
+	}
+	if result.BestScore < 0 || result.BestScore > 1 {
+		t.Fatalf("best score out of [0,1]: %f", result.BestScore)
+	}
+	for _, match := range result.Matches {
+		if match.Score < 0 || match.Score > 1 {
+			t.Fatalf("match %s score out of [0,1]: %f", match.Ref, match.Score)
+		}
+	}
+}
+
+func TestCombinedMatcher_Find_ContextCanceledWhileEmbeddingBlocked(t *testing.T) {
+	e := &blockingEmbedder{started: make(chan struct{}), release: make(chan struct{})}
+	defer close(e.release)
+
+	m := NewCombinedMatcher(e)
+	elements := []types.ElementDescriptor{
+		{Ref: "e1", Role: "button", Name: "Save"},
+		{Ref: "e2", Role: "link", Name: "Cancel"},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		_, err := m.Find(ctx, "save button", elements, types.FindOptions{Threshold: 0, TopK: 2})
+		done <- err
+	}()
+
+	select {
+	case <-e.started:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("expected embedding to start")
+	}
+
+	cancel()
+
+	select {
+	case err := <-done:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("expected context canceled error, got %v", err)
+		}
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("Find did not return promptly after context cancellation")
+	}
+}
+
+type blockingEmbedder struct {
+	started chan struct{}
+	release chan struct{}
+}
+
+func (e *blockingEmbedder) Strategy() string { return "blocking" }
+
+func (e *blockingEmbedder) Embed(texts []string) ([][]float32, error) {
+	close(e.started)
+	<-e.release
+	return fixedVectors(len(texts), 4), nil
 }

--- a/internal/engine/combined_test.go
+++ b/internal/engine/combined_test.go
@@ -97,6 +97,24 @@ func TestCombinedMatcher_TopK(t *testing.T) {
 	}
 }
 
+func TestCombinedMatcher_DeterministicTieBreak(t *testing.T) {
+	m := NewCombinedMatcher(NewHashingEmbedder(128))
+	elements := []types.ElementDescriptor{
+		{Ref: "first", Role: "button", Name: "Open", Positional: types.PositionalHints{Depth: 2, SiblingIndex: 0}},
+		{Ref: "second", Role: "button", Name: "Open", Positional: types.PositionalHints{Depth: 2, SiblingIndex: 0}},
+	}
+
+	for i := 0; i < 100; i++ {
+		result, err := m.Find(context.Background(), "open button", elements, types.FindOptions{Threshold: 0, TopK: 2})
+		if err != nil {
+			t.Fatalf("Find returned error: %v", err)
+		}
+		if result.BestRef != "first" {
+			t.Fatalf("run %d: expected BestRef=first, got %s", i, result.BestRef)
+		}
+	}
+}
+
 func TestCombinedMatcher_ScoresDescending(t *testing.T) {
 	m := NewCombinedMatcher(NewHashingEmbedder(128))
 

--- a/internal/engine/embedding.go
+++ b/internal/engine/embedding.go
@@ -75,18 +75,26 @@ func (m *EmbeddingMatcher) Find(_ context.Context, query string, elements []type
 	type scored struct {
 		desc  types.ElementDescriptor
 		score float64
+		order int
 	}
 
 	var candidates []scored
 	for i, el := range elements {
 		sim := CosineSimilarity(queryVec, contextVecs[i])
 		if sim >= opts.Threshold {
-			candidates = append(candidates, scored{desc: el, score: sim})
+			candidates = append(candidates, scored{desc: el, score: sim, order: i})
 		}
 	}
 
 	sort.Slice(candidates, func(i, j int) bool {
-		return candidates[i].score > candidates[j].score
+		return rankedMatchLess(
+			candidates[i].score,
+			candidates[i].desc,
+			candidates[i].order,
+			candidates[j].score,
+			candidates[j].desc,
+			candidates[j].order,
+		)
 	})
 
 	if len(candidates) > opts.TopK {

--- a/internal/engine/embedding.go
+++ b/internal/engine/embedding.go
@@ -2,6 +2,7 @@ package engine
 
 import (
 	"context"
+	"fmt"
 	"github.com/pinchtab/semantic/internal/types"
 	"math"
 	"sort"
@@ -47,10 +48,19 @@ func (m *EmbeddingMatcher) Strategy() string {
 	return "embedding:" + m.embedder.Strategy()
 }
 
-func (m *EmbeddingMatcher) Find(_ context.Context, query string, elements []types.ElementDescriptor, opts types.FindOptions) (types.FindResult, error) {
-	if opts.TopK <= 0 {
-		opts.TopK = 3
+type contextAwareEmbedder interface {
+	EmbedContext(ctx context.Context, texts []string) ([][]float32, error)
+}
+
+func (m *EmbeddingMatcher) Find(ctx context.Context, query string, elements []types.ElementDescriptor, opts types.FindOptions) (types.FindResult, error) {
+	if ctx == nil {
+		ctx = context.Background()
 	}
+	if err := ctx.Err(); err != nil {
+		return types.FindResult{}, err
+	}
+
+	opts = sanitizeFindOptions(opts, len(elements), 3)
 
 	// Build composite descriptions.
 	descs := make([]string, len(elements))
@@ -60,8 +70,15 @@ func (m *EmbeddingMatcher) Find(_ context.Context, query string, elements []type
 
 	// Embed query + all descriptions in a single batch.
 	texts := append([]string{query}, descs...)
-	vectors, err := m.embedder.Embed(texts)
+	vectors, err := embedWithContext(ctx, m.embedder, texts)
 	if err != nil {
+		return types.FindResult{}, err
+	}
+	if err := validateEmbeddedVectors(vectors, len(texts)); err != nil {
+		return types.FindResult{}, err
+	}
+
+	if err := ctx.Err(); err != nil {
 		return types.FindResult{}, err
 	}
 
@@ -80,6 +97,12 @@ func (m *EmbeddingMatcher) Find(_ context.Context, query string, elements []type
 
 	var candidates []scored
 	for i, el := range elements {
+		if i%64 == 0 {
+			if err := ctx.Err(); err != nil {
+				return types.FindResult{}, err
+			}
+		}
+
 		sim := CosineSimilarity(queryVec, contextVecs[i])
 		if sim >= opts.Threshold {
 			candidates = append(candidates, scored{desc: el, score: sim, order: i})
@@ -121,6 +144,35 @@ func (m *EmbeddingMatcher) Find(_ context.Context, query string, elements []type
 	}
 
 	return result, nil
+}
+
+func embedWithContext(ctx context.Context, embedder Embedder, texts []string) ([][]float32, error) {
+	if ce, ok := embedder.(contextAwareEmbedder); ok {
+		return ce.EmbedContext(ctx, texts)
+	}
+
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	return embedder.Embed(texts)
+}
+
+func validateEmbeddedVectors(vectors [][]float32, expected int) error {
+	if len(vectors) != expected {
+		return fmt.Errorf("embedder returned %d vectors, expected %d", len(vectors), expected)
+	}
+	if len(vectors) == 0 {
+		return nil
+	}
+
+	dim := len(vectors[0])
+	for i := 1; i < len(vectors); i++ {
+		if len(vectors[i]) != dim {
+			return fmt.Errorf("embedder returned inconsistent vector dimensions at index %d: %d vs %d", i, len(vectors[i]), dim)
+		}
+	}
+
+	return nil
 }
 
 func (m *EmbeddingMatcher) withNeighborContext(base [][]float32) [][]float32 {

--- a/internal/engine/embedding_test.go
+++ b/internal/engine/embedding_test.go
@@ -2,10 +2,12 @@ package engine
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"github.com/pinchtab/semantic/internal/types"
 	"math"
 	"testing"
+	"time"
 )
 
 // dummyEmbedder tests
@@ -278,6 +280,124 @@ func TestEmbeddingMatcher_SingleElement_WithNeighborWeight(t *testing.T) {
 	if len(res.Matches) != 1 {
 		t.Fatalf("expected one match, got %d", len(res.Matches))
 	}
+}
+
+func TestEmbeddingMatcher_Find_ContextCanceledBeforeEmbed(t *testing.T) {
+	e := &countingEmbedder{}
+	m := NewEmbeddingMatcher(e)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := m.Find(ctx, "save button", []types.ElementDescriptor{{Ref: "e1", Role: "button", Name: "Save"}}, types.FindOptions{Threshold: 0, TopK: 1})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context canceled error, got %v", err)
+	}
+	if e.calls != 0 {
+		t.Fatalf("embedder should not have been invoked on canceled context, calls=%d", e.calls)
+	}
+}
+
+func TestEmbeddingMatcher_Find_ContextCanceledDuringEmbedContext(t *testing.T) {
+	e := &blockingContextEmbedder{started: make(chan struct{}), release: make(chan struct{})}
+	defer close(e.release)
+
+	m := NewEmbeddingMatcher(e)
+	elements := []types.ElementDescriptor{{Ref: "e1", Role: "button", Name: "Save"}}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		_, err := m.Find(ctx, "save button", elements, types.FindOptions{Threshold: 0, TopK: 1})
+		done <- err
+	}()
+
+	select {
+	case <-e.started:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("expected embedding to start")
+	}
+
+	cancel()
+
+	select {
+	case err := <-done:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("expected context canceled error, got %v", err)
+		}
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("Find did not return promptly after context cancellation")
+	}
+}
+
+func TestEmbeddingMatcher_Find_EmbedderVectorCountMismatchReturnsError(t *testing.T) {
+	m := NewEmbeddingMatcher(&malformedEmbedder{
+		vectors: [][]float32{{1, 0, 0}},
+	})
+
+	_, err := m.Find(context.Background(), "query", []types.ElementDescriptor{
+		{Ref: "e1", Role: "button", Name: "Save"},
+		{Ref: "e2", Role: "button", Name: "Cancel"},
+	}, types.FindOptions{Threshold: 0, TopK: 2})
+	if err == nil {
+		t.Fatal("expected embedder vector count mismatch error")
+	}
+}
+
+func TestEmbeddingMatcher_Find_InconsistentVectorDimensionsReturnsError(t *testing.T) {
+	m := NewEmbeddingMatcher(&malformedEmbedder{
+		vectors: [][]float32{{1, 0}, {1}, {0, 1}},
+	})
+
+	_, err := m.Find(context.Background(), "query", []types.ElementDescriptor{
+		{Ref: "e1", Role: "button", Name: "Save"},
+		{Ref: "e2", Role: "button", Name: "Cancel"},
+	}, types.FindOptions{Threshold: 0, TopK: 2})
+	if err == nil {
+		t.Fatal("expected inconsistent embedding dimension error")
+	}
+}
+
+type countingEmbedder struct {
+	calls int
+}
+
+func (e *countingEmbedder) Strategy() string { return "counting" }
+
+func (e *countingEmbedder) Embed(texts []string) ([][]float32, error) {
+	e.calls++
+	return fixedVectors(len(texts), 4), nil
+}
+
+type blockingContextEmbedder struct {
+	started chan struct{}
+	release chan struct{}
+}
+
+func (e *blockingContextEmbedder) Strategy() string { return "blocking-context" }
+
+func (e *blockingContextEmbedder) Embed(texts []string) ([][]float32, error) {
+	return fixedVectors(len(texts), 4), nil
+}
+
+func (e *blockingContextEmbedder) EmbedContext(ctx context.Context, texts []string) ([][]float32, error) {
+	close(e.started)
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case <-e.release:
+		return fixedVectors(len(texts), 4), nil
+	}
+}
+
+type malformedEmbedder struct {
+	vectors [][]float32
+}
+
+func (e *malformedEmbedder) Strategy() string { return "malformed" }
+
+func (e *malformedEmbedder) Embed(_ []string) ([][]float32, error) {
+	return e.vectors, nil
 }
 
 type scriptedEmbedder struct {

--- a/internal/engine/embedding_test.go
+++ b/internal/engine/embedding_test.go
@@ -187,6 +187,28 @@ func TestEmbeddingMatcher_ThresholdFiltering(t *testing.T) {
 	}
 }
 
+func TestEmbeddingMatcher_TieBreaksByPositionalHints(t *testing.T) {
+	e := newScriptedEmbedder(map[string][]float32{
+		"open button":  {1, 0, 0},
+		"button: Open": {1, 0, 0},
+	})
+	m := NewEmbeddingMatcherWithNeighborWeight(e, 0)
+
+	elements := []types.ElementDescriptor{
+		{Ref: "shallow", Role: "button", Name: "Open", Positional: types.PositionalHints{Depth: 1, SiblingIndex: 1}},
+		{Ref: "deep-left", Role: "button", Name: "Open", Positional: types.PositionalHints{Depth: 3, SiblingIndex: 0}},
+		{Ref: "deep-right", Role: "button", Name: "Open", Positional: types.PositionalHints{Depth: 3, SiblingIndex: 2}},
+	}
+
+	res, err := m.Find(context.Background(), "open button", elements, types.FindOptions{Threshold: 0, TopK: 3})
+	if err != nil {
+		t.Fatalf("Find failed: %v", err)
+	}
+	if res.BestRef != "deep-left" {
+		t.Fatalf("expected deep-left to win tie-break, got %s", res.BestRef)
+	}
+}
+
 func TestEmbeddingMatcher_NeighborContextDisambiguatesRealWorldButtons(t *testing.T) {
 	e := newScriptedEmbedder(map[string][]float32{
 		"laptop add to cart":         {1, 1, 0},

--- a/internal/engine/hashing.go
+++ b/internal/engine/hashing.go
@@ -1,6 +1,7 @@
 package engine
 
 import (
+	"context"
 	"hash/fnv"
 	"math"
 	"strings"
@@ -39,8 +40,25 @@ func NewHashingEmbedder(dim int) *HashingEmbedder {
 func (h *HashingEmbedder) Strategy() string { return "hashing" }
 
 func (h *HashingEmbedder) Embed(texts []string) ([][]float32, error) {
+	return h.EmbedContext(context.Background(), texts)
+}
+
+func (h *HashingEmbedder) EmbedContext(ctx context.Context, texts []string) ([][]float32, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
 	result := make([][]float32, len(texts))
 	for i, text := range texts {
+		if i%64 == 0 {
+			if err := ctx.Err(); err != nil {
+				return nil, err
+			}
+		}
+
 		result[i] = h.vectorize(text)
 	}
 	return result, nil

--- a/internal/engine/lexical.go
+++ b/internal/engine/lexical.go
@@ -47,10 +47,15 @@ func NewLexicalMatcher() *LexicalMatcher {
 
 func (m *LexicalMatcher) Strategy() string { return "lexical" }
 
-func (m *LexicalMatcher) Find(_ context.Context, query string, elements []types.ElementDescriptor, opts types.FindOptions) (types.FindResult, error) {
-	if opts.TopK <= 0 {
-		opts.TopK = 3
+func (m *LexicalMatcher) Find(ctx context.Context, query string, elements []types.ElementDescriptor, opts types.FindOptions) (types.FindResult, error) {
+	if ctx == nil {
+		ctx = context.Background()
 	}
+	if err := ctx.Err(); err != nil {
+		return types.FindResult{}, err
+	}
+
+	opts = sanitizeFindOptions(opts, len(elements), 3)
 
 	ef := BuildElementFrequency(elements)
 
@@ -60,7 +65,13 @@ func (m *LexicalMatcher) Find(_ context.Context, query string, elements []types.
 	}
 
 	var candidates []scored
-	for _, el := range elements {
+	for i, el := range elements {
+		if i%64 == 0 {
+			if err := ctx.Err(); err != nil {
+				return types.FindResult{}, err
+			}
+		}
+
 		composite := el.Composite()
 		score := lexicalScore(query, composite, el.Interactive, ef)
 		score += positionalBoost(query, el.Positional)

--- a/internal/engine/lexical_test.go
+++ b/internal/engine/lexical_test.go
@@ -2,11 +2,24 @@ package engine
 
 import (
 	"context"
+	"errors"
 	"github.com/pinchtab/semantic/internal/types"
 	"math"
 	"strconv"
 	"testing"
 )
+
+func TestLexicalMatcher_Find_ContextCanceled(t *testing.T) {
+	m := NewLexicalMatcher()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := m.Find(ctx, "submit button", []types.ElementDescriptor{{Ref: "e1", Role: "button", Name: "Submit"}}, types.FindOptions{Threshold: 0, TopK: 1})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context canceled error, got %v", err)
+	}
+}
 
 func TestTokenPrefixScore_BtnButton(t *testing.T) {
 	// "btn" is NOT a string prefix of "button" (b-t-n vs b-u-t-t-o-n),

--- a/internal/engine/options.go
+++ b/internal/engine/options.go
@@ -1,0 +1,36 @@
+package engine
+
+import (
+	"math"
+
+	"github.com/pinchtab/semantic/internal/types"
+)
+
+func sanitizeFindOptions(opts types.FindOptions, elementCount int, defaultTopK int) types.FindOptions {
+	if defaultTopK <= 0 {
+		defaultTopK = 3
+	}
+
+	if opts.TopK <= 0 {
+		opts.TopK = defaultTopK
+	}
+	if elementCount >= 0 && opts.TopK > elementCount {
+		opts.TopK = elementCount
+	}
+
+	opts.Threshold = sanitizeThreshold(opts.Threshold)
+	return opts
+}
+
+func sanitizeThreshold(threshold float64) float64 {
+	if math.IsNaN(threshold) || math.IsInf(threshold, 0) {
+		return 0
+	}
+	if threshold < 0 {
+		return 0
+	}
+	if threshold > 1 {
+		return 1
+	}
+	return threshold
+}

--- a/internal/engine/query_visual.go
+++ b/internal/engine/query_visual.go
@@ -1,0 +1,374 @@
+package engine
+
+import (
+	"sort"
+	"strings"
+
+	"github.com/pinchtab/semantic/internal/types"
+)
+
+const (
+	visualDirectionalBoost = 0.12
+	visualRelativeBoost    = 0.16
+	visualRelativePenalty  = 0.05
+	visualBoostCap         = 0.30
+)
+
+type visualQueryHints struct {
+	hasHints    bool
+	baseQuery   string
+	top         bool
+	bottom      bool
+	left        bool
+	right       bool
+	aboveAnchor string
+	belowAnchor string
+}
+
+var visualKeywordSet = map[string]bool{
+	"top":    true,
+	"bottom": true,
+	"left":   true,
+	"right":  true,
+	"corner": true,
+	"above":  true,
+	"below":  true,
+	"under":  true,
+	"over":   true,
+	"in":     true,
+	"on":     true,
+	"at":     true,
+	"the":    true,
+	"a":      true,
+	"an":     true,
+	"of":     true,
+	"page":   true,
+	"side":   true,
+}
+
+func parseVisualQueryHints(query string) visualQueryHints {
+	cleaned := strings.TrimSpace(query)
+	if cleaned == "" {
+		return visualQueryHints{}
+	}
+
+	words := tokenSet(tokenize(cleaned))
+	hints := visualQueryHints{
+		top:       words["top"],
+		bottom:    words["bottom"],
+		left:      words["left"],
+		right:     words["right"],
+		baseQuery: cleaned,
+	}
+	hasDirectional := hints.top || hints.bottom || hints.left || hints.right || words["corner"]
+	hasRelative := false
+
+	lower := strings.ToLower(cleaned)
+	if idx := strings.Index(lower, " below "); idx >= 0 {
+		hints.belowAnchor = normalizeVisualAnchor(cleaned[idx+len(" below "):])
+		hasRelative = true
+		if base := strings.TrimSpace(cleaned[:idx]); base != "" {
+			hints.baseQuery = stripVisualKeywords(base)
+		}
+	}
+	if idx := strings.Index(lower, " under "); idx >= 0 {
+		hints.belowAnchor = normalizeVisualAnchor(cleaned[idx+len(" under "):])
+		hasRelative = true
+		if base := strings.TrimSpace(cleaned[:idx]); base != "" {
+			hints.baseQuery = stripVisualKeywords(base)
+		}
+	}
+	if idx := strings.Index(lower, " above "); idx >= 0 {
+		hints.aboveAnchor = normalizeVisualAnchor(cleaned[idx+len(" above "):])
+		hasRelative = true
+		if base := strings.TrimSpace(cleaned[:idx]); base != "" {
+			hints.baseQuery = stripVisualKeywords(base)
+		}
+	}
+	if idx := strings.Index(lower, " over "); idx >= 0 {
+		hints.aboveAnchor = normalizeVisualAnchor(cleaned[idx+len(" over "):])
+		hasRelative = true
+		if base := strings.TrimSpace(cleaned[:idx]); base != "" {
+			hints.baseQuery = stripVisualKeywords(base)
+		}
+	}
+
+	if !hasRelative && hasDirectional {
+		hints.baseQuery = stripVisualKeywords(cleaned)
+	}
+	if strings.TrimSpace(hints.baseQuery) == "" {
+		hints.baseQuery = cleaned
+	}
+
+	hints.hasHints = hasDirectional || hints.aboveAnchor != "" || hints.belowAnchor != ""
+	return hints
+}
+
+func stripVisualKeywords(query string) string {
+	parts := tokenize(query)
+	filtered := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if !visualKeywordSet[p] {
+			filtered = append(filtered, p)
+		}
+	}
+	return strings.TrimSpace(strings.Join(filtered, " "))
+}
+
+func normalizeVisualAnchor(s string) string {
+	anchor := stripVisualKeywords(s)
+	if anchor == "" {
+		anchor = strings.TrimSpace(strings.ToLower(s))
+	}
+	return anchor
+}
+
+type spatialStats struct {
+	hasX bool
+	hasY bool
+	minX float64
+	maxX float64
+	minY float64
+	maxY float64
+}
+
+func buildSpatialStats(elements []types.ElementDescriptor) spatialStats {
+	stats := spatialStats{}
+	for _, el := range elements {
+		h := el.Positional
+		if hasHorizontalPosition(h) {
+			x := horizontalPosition(h)
+			if !stats.hasX {
+				stats.hasX = true
+				stats.minX, stats.maxX = x, x
+			} else {
+				if x < stats.minX {
+					stats.minX = x
+				}
+				if x > stats.maxX {
+					stats.maxX = x
+				}
+			}
+		}
+		if hasVerticalPosition(h) {
+			y := verticalPosition(h)
+			if !stats.hasY {
+				stats.hasY = true
+				stats.minY, stats.maxY = y, y
+			} else {
+				if y < stats.minY {
+					stats.minY = y
+				}
+				if y > stats.maxY {
+					stats.maxY = y
+				}
+			}
+		}
+	}
+	return stats
+}
+
+func applyVisualHintBoost(result types.FindResult, hints visualQueryHints, elements []types.ElementDescriptor, topK int) types.FindResult {
+	if !hints.hasHints || len(result.Matches) == 0 {
+		return result
+	}
+
+	refToElem := make(map[string]types.ElementDescriptor, len(elements))
+	refOrder := make(map[string]int, len(elements))
+	for i, el := range elements {
+		refToElem[el.Ref] = el
+		refOrder[el.Ref] = i
+	}
+
+	stats := buildSpatialStats(elements)
+	anchorRef := ""
+	if hints.aboveAnchor != "" {
+		anchorRef = findVisualAnchorRef(hints.aboveAnchor, elements)
+	} else if hints.belowAnchor != "" {
+		anchorRef = findVisualAnchorRef(hints.belowAnchor, elements)
+	}
+
+	type boostedMatch struct {
+		match types.ElementMatch
+		order int
+	}
+
+	boosted := make([]boostedMatch, 0, len(result.Matches))
+	for _, match := range result.Matches {
+		el, ok := refToElem[match.Ref]
+		if !ok {
+			continue
+		}
+		order := refOrder[match.Ref]
+		boost := computeVisualBoost(el, order, len(elements), hints, stats, anchorRef, refToElem, refOrder)
+		if boost > visualBoostCap {
+			boost = visualBoostCap
+		}
+		if boost < -visualBoostCap {
+			boost = -visualBoostCap
+		}
+		match.Score += boost
+		if match.Score > 1.0 {
+			match.Score = 1.0
+		}
+		if match.Score < 0 {
+			match.Score = 0
+		}
+		boosted = append(boosted, boostedMatch{match: match, order: order})
+	}
+
+	sort.SliceStable(boosted, func(i, j int) bool {
+		diff := boosted[i].match.Score - boosted[j].match.Score
+		if diff > 1e-9 || diff < -1e-9 {
+			return diff > 0
+		}
+		if boosted[i].order != boosted[j].order {
+			return boosted[i].order < boosted[j].order
+		}
+		return boosted[i].match.Ref < boosted[j].match.Ref
+	})
+
+	if topK > 0 && len(boosted) > topK {
+		boosted = boosted[:topK]
+	}
+
+	result.Matches = result.Matches[:0]
+	for _, bm := range boosted {
+		result.Matches = append(result.Matches, bm.match)
+	}
+	if len(result.Matches) > 0 {
+		result.BestRef = result.Matches[0].Ref
+		result.BestScore = result.Matches[0].Score
+	} else {
+		result.BestRef = ""
+		result.BestScore = 0
+	}
+	return result
+}
+
+func computeVisualBoost(
+	el types.ElementDescriptor,
+	order int,
+	total int,
+	hints visualQueryHints,
+	stats spatialStats,
+	anchorRef string,
+	refToElem map[string]types.ElementDescriptor,
+	refOrder map[string]int,
+) float64 {
+	xRatio := horizontalRatio(el.Positional, stats, order, total)
+	yRatio := verticalRatio(el.Positional, stats, order, total)
+
+	boost := 0.0
+	if hints.top {
+		boost += visualDirectionalBoost * (1 - yRatio)
+	}
+	if hints.bottom {
+		boost += visualDirectionalBoost * yRatio
+	}
+	if hints.left {
+		boost += visualDirectionalBoost * (1 - xRatio)
+	}
+	if hints.right {
+		boost += visualDirectionalBoost * xRatio
+	}
+
+	if anchorRef != "" && anchorRef != el.Ref {
+		anchorEl, ok := refToElem[anchorRef]
+		if ok {
+			anchorOrder := refOrder[anchorRef]
+			anchorY := verticalRatio(anchorEl.Positional, stats, anchorOrder, total)
+			if hints.aboveAnchor != "" {
+				if yRatio < anchorY {
+					boost += visualRelativeBoost
+				} else {
+					boost -= visualRelativePenalty
+				}
+			}
+			if hints.belowAnchor != "" {
+				if yRatio > anchorY {
+					boost += visualRelativeBoost
+				} else {
+					boost -= visualRelativePenalty
+				}
+			}
+		}
+	}
+
+	return boost
+}
+
+func findVisualAnchorRef(anchorQuery string, elements []types.ElementDescriptor) string {
+	if strings.TrimSpace(anchorQuery) == "" {
+		return ""
+	}
+	bestRef := ""
+	bestScore := 0.0
+	for _, el := range elements {
+		anchorContext := strings.TrimSpace(el.Composite() + " " + el.Parent + " " + el.Section)
+		score := lexicalScore(anchorQuery, anchorContext, false, nil)
+		if score > bestScore {
+			bestScore = score
+			bestRef = el.Ref
+		}
+	}
+	if bestScore < 0.2 {
+		return ""
+	}
+	return bestRef
+}
+
+func horizontalRatio(h types.PositionalHints, stats spatialStats, order, total int) float64 {
+	if stats.hasX && hasHorizontalPosition(h) {
+		x := horizontalPosition(h)
+		if stats.maxX > stats.minX {
+			return (x - stats.minX) / (stats.maxX - stats.minX)
+		}
+		return 0.5
+	}
+	return fallbackOrderRatio(h, order, total)
+}
+
+func verticalRatio(h types.PositionalHints, stats spatialStats, order, total int) float64 {
+	if stats.hasY && hasVerticalPosition(h) {
+		y := verticalPosition(h)
+		if stats.maxY > stats.minY {
+			return (y - stats.minY) / (stats.maxY - stats.minY)
+		}
+		return 0.5
+	}
+	return fallbackOrderRatio(h, order, total)
+}
+
+func fallbackOrderRatio(h types.PositionalHints, order, total int) float64 {
+	if h.SiblingCount > 1 {
+		idx := h.SiblingIndex
+		if idx < 0 {
+			idx = 0
+		}
+		if idx > h.SiblingCount-1 {
+			idx = h.SiblingCount - 1
+		}
+		return float64(idx) / float64(h.SiblingCount-1)
+	}
+	if total > 1 {
+		return float64(order) / float64(total-1)
+	}
+	return 0.5
+}
+
+func hasHorizontalPosition(h types.PositionalHints) bool {
+	return h.Width > 0 || h.X != 0
+}
+
+func hasVerticalPosition(h types.PositionalHints) bool {
+	return h.Height > 0 || h.Y != 0
+}
+
+func horizontalPosition(h types.PositionalHints) float64 {
+	return h.X + (h.Width / 2)
+}
+
+func verticalPosition(h types.PositionalHints) float64 {
+	return h.Y + (h.Height / 2)
+}

--- a/internal/engine/query_visual_test.go
+++ b/internal/engine/query_visual_test.go
@@ -1,0 +1,137 @@
+package engine
+
+import (
+	"context"
+	"testing"
+
+	"github.com/pinchtab/semantic/internal/types"
+)
+
+func TestParseVisualQueryHints_BasicPatterns(t *testing.T) {
+	tests := []struct {
+		name        string
+		query       string
+		wantBase    string
+		wantTop     bool
+		wantBottom  bool
+		wantLeft    bool
+		wantRight   bool
+		wantAbove   string
+		wantBelow   string
+		wantHasHint bool
+	}{
+		{
+			name:        "top right corner",
+			query:       "button in top right corner",
+			wantBase:    "button",
+			wantTop:     true,
+			wantRight:   true,
+			wantHasHint: true,
+		},
+		{
+			name:        "below anchor",
+			query:       "link below the search box",
+			wantBase:    "link",
+			wantBelow:   "search box",
+			wantHasHint: true,
+		},
+		{
+			name:        "left side",
+			query:       "sidebar on the left",
+			wantBase:    "sidebar",
+			wantLeft:    true,
+			wantHasHint: true,
+		},
+		{
+			name:        "plain query",
+			query:       "submit button",
+			wantBase:    "submit button",
+			wantHasHint: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseVisualQueryHints(tt.query)
+			if got.baseQuery != tt.wantBase {
+				t.Fatalf("base query mismatch: want=%q got=%q", tt.wantBase, got.baseQuery)
+			}
+			if got.top != tt.wantTop || got.bottom != tt.wantBottom || got.left != tt.wantLeft || got.right != tt.wantRight {
+				t.Fatalf("directional hints mismatch: got top=%v bottom=%v left=%v right=%v", got.top, got.bottom, got.left, got.right)
+			}
+			if got.aboveAnchor != tt.wantAbove || got.belowAnchor != tt.wantBelow {
+				t.Fatalf("anchor mismatch: got above=%q below=%q", got.aboveAnchor, got.belowAnchor)
+			}
+			if got.hasHints != tt.wantHasHint {
+				t.Fatalf("hasHints mismatch: want=%v got=%v", tt.wantHasHint, got.hasHints)
+			}
+		})
+	}
+}
+
+func TestCombinedMatcher_VisualHint_TopRightCorner(t *testing.T) {
+	m := NewCombinedMatcher(NewHashingEmbedder(128))
+	elements := []types.ElementDescriptor{
+		{Ref: "btn-left-top", Role: "button", Name: "Open", Positional: types.PositionalHints{X: 20, Y: 20, Width: 80, Height: 24}},
+		{Ref: "btn-right-top", Role: "button", Name: "Open", Positional: types.PositionalHints{X: 880, Y: 30, Width: 80, Height: 24}},
+		{Ref: "btn-right-bottom", Role: "button", Name: "Open", Positional: types.PositionalHints{X: 860, Y: 620, Width: 80, Height: 24}},
+	}
+
+	res, err := m.Find(context.Background(), "button in top right corner", elements, types.FindOptions{Threshold: 0, TopK: 3})
+	if err != nil {
+		t.Fatalf("Find failed: %v", err)
+	}
+	if res.BestRef != "btn-right-top" {
+		t.Fatalf("expected top-right button, got %s", res.BestRef)
+	}
+}
+
+func TestCombinedMatcher_VisualHint_BelowAnchor(t *testing.T) {
+	m := NewCombinedMatcher(NewHashingEmbedder(128))
+	elements := []types.ElementDescriptor{
+		{Ref: "search", Role: "searchbox", Name: "Search", Positional: types.PositionalHints{X: 120, Y: 40, Width: 320, Height: 32}},
+		{Ref: "link-top", Role: "link", Name: "Help", Positional: types.PositionalHints{X: 140, Y: 10, Width: 70, Height: 20}},
+		{Ref: "link-bottom", Role: "link", Name: "Help", Positional: types.PositionalHints{X: 140, Y: 160, Width: 70, Height: 20}},
+	}
+
+	res, err := m.Find(context.Background(), "link below the search box", elements, types.FindOptions{Threshold: 0, TopK: 3})
+	if err != nil {
+		t.Fatalf("Find failed: %v", err)
+	}
+	if res.BestRef != "link-bottom" {
+		t.Fatalf("expected link below anchor, got %s", res.BestRef)
+	}
+}
+
+func TestCombinedMatcher_VisualHint_LeftSidebar(t *testing.T) {
+	m := NewCombinedMatcher(NewHashingEmbedder(128))
+	elements := []types.ElementDescriptor{
+		{Ref: "sidebar-left", Role: "navigation", Name: "Sidebar", Positional: types.PositionalHints{X: 10, Y: 120, Width: 200, Height: 600}},
+		{Ref: "sidebar-right", Role: "navigation", Name: "Sidebar", Positional: types.PositionalHints{X: 980, Y: 120, Width: 200, Height: 600}},
+	}
+
+	res, err := m.Find(context.Background(), "sidebar on the left", elements, types.FindOptions{Threshold: 0, TopK: 2})
+	if err != nil {
+		t.Fatalf("Find failed: %v", err)
+	}
+	if res.BestRef != "sidebar-left" {
+		t.Fatalf("expected left sidebar, got %s", res.BestRef)
+	}
+}
+
+func TestCombinedMatcher_VisualHint_BottomFallbackWithoutCoordinates(t *testing.T) {
+	m := NewCombinedMatcher(NewHashingEmbedder(128))
+	elements := []types.ElementDescriptor{
+		{Ref: "button-1", Role: "button", Name: "Submit", Positional: types.PositionalHints{SiblingIndex: 0, SiblingCount: 3}},
+		{Ref: "button-2", Role: "button", Name: "Submit", Positional: types.PositionalHints{SiblingIndex: 1, SiblingCount: 3}},
+		{Ref: "button-3", Role: "button", Name: "Submit", Positional: types.PositionalHints{SiblingIndex: 2, SiblingCount: 3}},
+	}
+
+	res, err := m.Find(context.Background(), "button at bottom of page", elements, types.FindOptions{Threshold: 0, TopK: 3})
+	if err != nil {
+		t.Fatalf("Find failed: %v", err)
+	}
+	if res.BestRef != "button-3" {
+		t.Fatalf("expected bottom-most fallback button, got %s", res.BestRef)
+	}
+}

--- a/internal/engine/query_visual_test.go
+++ b/internal/engine/query_visual_test.go
@@ -69,6 +69,16 @@ func TestParseVisualQueryHints_BasicPatterns(t *testing.T) {
 	}
 }
 
+func TestParseVisualQueryHints_DoesNotTreatSignInAsVisualHint(t *testing.T) {
+	got := parseVisualQueryHints("sign in button")
+	if got.hasHints {
+		t.Fatalf("expected hasHints=false for non-visual query, got true")
+	}
+	if got.baseQuery != "sign in button" {
+		t.Fatalf("expected base query to stay unchanged, got %q", got.baseQuery)
+	}
+}
+
 func TestCombinedMatcher_VisualHint_TopRightCorner(t *testing.T) {
 	m := NewCombinedMatcher(NewHashingEmbedder(128))
 	elements := []types.ElementDescriptor{

--- a/internal/engine/ranking.go
+++ b/internal/engine/ranking.go
@@ -1,0 +1,36 @@
+package engine
+
+import (
+	"math"
+
+	"github.com/pinchtab/semantic/internal/types"
+)
+
+// rankedMatchLess defines deterministic ordering for scored matches.
+func rankedMatchLess(
+	aScore float64,
+	aDesc types.ElementDescriptor,
+	aOrder int,
+	bScore float64,
+	bDesc types.ElementDescriptor,
+	bOrder int,
+) bool {
+	scoreDiff := aScore - bScore
+	if math.Abs(scoreDiff) > 1e-9 {
+		return scoreDiff > 0
+	}
+
+	if aDesc.Positional.Depth != bDesc.Positional.Depth {
+		return aDesc.Positional.Depth > bDesc.Positional.Depth
+	}
+
+	if aDesc.Positional.SiblingIndex != bDesc.Positional.SiblingIndex {
+		return aDesc.Positional.SiblingIndex < bDesc.Positional.SiblingIndex
+	}
+
+	if aOrder != bOrder {
+		return aOrder < bOrder
+	}
+
+	return aDesc.Ref < bDesc.Ref
+}

--- a/internal/engine/testing_helpers_test.go
+++ b/internal/engine/testing_helpers_test.go
@@ -47,3 +47,16 @@ func (d *dummyEmbedder) hashVec(s string) []float32 {
 	}
 	return vec
 }
+
+func fixedVectors(n, dim int) [][]float32 {
+	if dim <= 0 {
+		dim = 1
+	}
+	vectors := make([][]float32, n)
+	for i := 0; i < n; i++ {
+		vec := make([]float32, dim)
+		vec[i%dim] = 1
+		vectors[i] = vec
+	}
+	return vectors
+}

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -36,7 +36,9 @@ type FindOptions struct {
 	TopK int
 
 	// Per-request weight overrides (optional). If both are zero the
-	// matcher's default weights are used.
+	// matcher's default weights are used. If only one weight is set,
+	// the other receives the remaining proportion. Weights are clamped
+	// to non-negative values and normalized to sum to 1.
 	LexicalWeight   float64
 	EmbeddingWeight float64
 

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -82,6 +82,10 @@ type PositionalHints struct {
 	SiblingIndex int
 	SiblingCount int
 	LabelledBy   string
+	X            float64
+	Y            float64
+	Width        float64
+	Height       float64
 }
 
 // ElementDescriptor describes a single accessibility tree node.


### PR DESCRIPTION
## Summary
Hardens combined fusion behavior by normalizing unsafe weight inputs and bounding merged scores.

## Changes
- Normalize and sanitize lexical/embedding fusion weights.
- Add safe defaults when provided weights are invalid.
- Bound combined scores into [0,1].
- Add robust regression tests around weight semantics and score bounds.

## Validation
- go test ./...


## Stack Flow
- PR 32 (base hardening): https://github.com/pinchtab/semantic/pull/32
- PR 33 (runtime cancellation hardening): https://github.com/pinchtab/semantic/pull/33
- PR 34 (adversarial options matrix): https://github.com/pinchtab/semantic/pull/34
