### PR TITLE
hardening: add cancellation-safe matcher execution paths

### DIFF
--- a/internal/engine/embedding.go
+++ b/internal/engine/embedding.go
@@ -2,6 +2,7 @@ package engine
 
 import (
 	"context"
+	"fmt"
 	"github.com/pinchtab/semantic/internal/types"
 	"math"
 	"sort"
@@ -47,10 +48,19 @@ func (m *EmbeddingMatcher) Strategy() string {
 	return "embedding:" + m.embedder.Strategy()
 }
 
-func (m *EmbeddingMatcher) Find(_ context.Context, query string, elements []types.ElementDescriptor, opts types.FindOptions) (types.FindResult, error) {
-	if opts.TopK <= 0 {
-		opts.TopK = 3
+type contextAwareEmbedder interface {
+	EmbedContext(ctx context.Context, texts []string) ([][]float32, error)
+}
+
+func (m *EmbeddingMatcher) Find(ctx context.Context, query string, elements []types.ElementDescriptor, opts types.FindOptions) (types.FindResult, error) {
+	if ctx == nil {
+		ctx = context.Background()
 	}
+	if err := ctx.Err(); err != nil {
+		return types.FindResult{}, err
+	}
+
+	opts = sanitizeFindOptions(opts, len(elements), 3)
 
 	// Build composite descriptions.
 	descs := make([]string, len(elements))
@@ -60,8 +70,15 @@ func (m *EmbeddingMatcher) Find(_ context.Context, query string, elements []type
 
 	// Embed query + all descriptions in a single batch.
 	texts := append([]string{query}, descs...)
-	vectors, err := m.embedder.Embed(texts)
+	vectors, err := embedWithContext(ctx, m.embedder, texts)
 	if err != nil {
+		return types.FindResult{}, err
+	}
+	if err := validateEmbeddedVectors(vectors, len(texts)); err != nil {
+		return types.FindResult{}, err
+	}
+
+	if err := ctx.Err(); err != nil {
 		return types.FindResult{}, err
 	}
 
@@ -80,6 +97,12 @@ func (m *EmbeddingMatcher) Find(_ context.Context, query string, elements []type
 
 	var candidates []scored
 	for i, el := range elements {
+		if i%64 == 0 {
+			if err := ctx.Err(); err != nil {
+				return types.FindResult{}, err
+			}
+		}
+
 		sim := CosineSimilarity(queryVec, contextVecs[i])
 		if sim >= opts.Threshold {
 			candidates = append(candidates, scored{desc: el, score: sim, order: i})
@@ -121,6 +144,35 @@ func (m *EmbeddingMatcher) Find(_ context.Context, query string, elements []type
 	}
 
 	return result, nil
+}
+
+func embedWithContext(ctx context.Context, embedder Embedder, texts []string) ([][]float32, error) {
+	if ce, ok := embedder.(contextAwareEmbedder); ok {
+		return ce.EmbedContext(ctx, texts)
+	}
+
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	return embedder.Embed(texts)
+}
+
+func validateEmbeddedVectors(vectors [][]float32, expected int) error {
+	if len(vectors) != expected {
+		return fmt.Errorf("embedder returned %d vectors, expected %d", len(vectors), expected)
+	}
+	if len(vectors) == 0 {
+		return nil
+	}
+
+	dim := len(vectors[0])
+	for i := 1; i < len(vectors); i++ {
+		if len(vectors[i]) != dim {
+			return fmt.Errorf("embedder returned inconsistent vector dimensions at index %d: %d vs %d", i, len(vectors[i]), dim)
+		}
+	}
+
+	return nil
 }
 
 func (m *EmbeddingMatcher) withNeighborContext(base [][]float32) [][]float32 {

--- a/internal/engine/embedding_test.go
+++ b/internal/engine/embedding_test.go
@@ -2,10 +2,12 @@ package engine
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"github.com/pinchtab/semantic/internal/types"
 	"math"
 	"testing"
+	"time"
 )
 
 // dummyEmbedder tests
@@ -278,6 +280,124 @@ func TestEmbeddingMatcher_SingleElement_WithNeighborWeight(t *testing.T) {
 	if len(res.Matches) != 1 {
 		t.Fatalf("expected one match, got %d", len(res.Matches))
 	}
+}
+
+func TestEmbeddingMatcher_Find_ContextCanceledBeforeEmbed(t *testing.T) {
+	e := &countingEmbedder{}
+	m := NewEmbeddingMatcher(e)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := m.Find(ctx, "save button", []types.ElementDescriptor{{Ref: "e1", Role: "button", Name: "Save"}}, types.FindOptions{Threshold: 0, TopK: 1})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context canceled error, got %v", err)
+	}
+	if e.calls != 0 {
+		t.Fatalf("embedder should not have been invoked on canceled context, calls=%d", e.calls)
+	}
+}
+
+func TestEmbeddingMatcher_Find_ContextCanceledDuringEmbedContext(t *testing.T) {
+	e := &blockingContextEmbedder{started: make(chan struct{}), release: make(chan struct{})}
+	defer close(e.release)
+
+	m := NewEmbeddingMatcher(e)
+	elements := []types.ElementDescriptor{{Ref: "e1", Role: "button", Name: "Save"}}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		_, err := m.Find(ctx, "save button", elements, types.FindOptions{Threshold: 0, TopK: 1})
+		done <- err
+	}()
+
+	select {
+	case <-e.started:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("expected embedding to start")
+	}
+
+	cancel()
+
+	select {
+	case err := <-done:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("expected context canceled error, got %v", err)
+		}
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("Find did not return promptly after context cancellation")
+	}
+}
+
+func TestEmbeddingMatcher_Find_EmbedderVectorCountMismatchReturnsError(t *testing.T) {
+	m := NewEmbeddingMatcher(&malformedEmbedder{
+		vectors: [][]float32{{1, 0, 0}},
+	})
+
+	_, err := m.Find(context.Background(), "query", []types.ElementDescriptor{
+		{Ref: "e1", Role: "button", Name: "Save"},
+		{Ref: "e2", Role: "button", Name: "Cancel"},
+	}, types.FindOptions{Threshold: 0, TopK: 2})
+	if err == nil {
+		t.Fatal("expected embedder vector count mismatch error")
+	}
+}
+
+func TestEmbeddingMatcher_Find_InconsistentVectorDimensionsReturnsError(t *testing.T) {
+	m := NewEmbeddingMatcher(&malformedEmbedder{
+		vectors: [][]float32{{1, 0}, {1}, {0, 1}},
+	})
+
+	_, err := m.Find(context.Background(), "query", []types.ElementDescriptor{
+		{Ref: "e1", Role: "button", Name: "Save"},
+		{Ref: "e2", Role: "button", Name: "Cancel"},
+	}, types.FindOptions{Threshold: 0, TopK: 2})
+	if err == nil {
+		t.Fatal("expected inconsistent embedding dimension error")
+	}
+}
+
+type countingEmbedder struct {
+	calls int
+}
+
+func (e *countingEmbedder) Strategy() string { return "counting" }
+
+func (e *countingEmbedder) Embed(texts []string) ([][]float32, error) {
+	e.calls++
+	return fixedVectors(len(texts), 4), nil
+}
+
+type blockingContextEmbedder struct {
+	started chan struct{}
+	release chan struct{}
+}
+
+func (e *blockingContextEmbedder) Strategy() string { return "blocking-context" }
+
+func (e *blockingContextEmbedder) Embed(texts []string) ([][]float32, error) {
+	return fixedVectors(len(texts), 4), nil
+}
+
+func (e *blockingContextEmbedder) EmbedContext(ctx context.Context, texts []string) ([][]float32, error) {
+	close(e.started)
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case <-e.release:
+		return fixedVectors(len(texts), 4), nil
+	}
+}
+
+type malformedEmbedder struct {
+	vectors [][]float32
+}
+
+func (e *malformedEmbedder) Strategy() string { return "malformed" }
+
+func (e *malformedEmbedder) Embed(_ []string) ([][]float32, error) {
+	return e.vectors, nil
 }
 
 type scriptedEmbedder struct {

--- a/internal/engine/hashing.go
+++ b/internal/engine/hashing.go
@@ -1,6 +1,7 @@
 package engine
 
 import (
+	"context"
 	"hash/fnv"
 	"math"
 	"strings"
@@ -39,8 +40,25 @@ func NewHashingEmbedder(dim int) *HashingEmbedder {
 func (h *HashingEmbedder) Strategy() string { return "hashing" }
 
 func (h *HashingEmbedder) Embed(texts []string) ([][]float32, error) {
+	return h.EmbedContext(context.Background(), texts)
+}
+
+func (h *HashingEmbedder) EmbedContext(ctx context.Context, texts []string) ([][]float32, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
 	result := make([][]float32, len(texts))
 	for i, text := range texts {
+		if i%64 == 0 {
+			if err := ctx.Err(); err != nil {
+				return nil, err
+			}
+		}
+
 		result[i] = h.vectorize(text)
 	}
 	return result, nil

--- a/internal/engine/lexical.go
+++ b/internal/engine/lexical.go
@@ -47,10 +47,15 @@ func NewLexicalMatcher() *LexicalMatcher {
 
 func (m *LexicalMatcher) Strategy() string { return "lexical" }
 
-func (m *LexicalMatcher) Find(_ context.Context, query string, elements []types.ElementDescriptor, opts types.FindOptions) (types.FindResult, error) {
-	if opts.TopK <= 0 {
-		opts.TopK = 3
+func (m *LexicalMatcher) Find(ctx context.Context, query string, elements []types.ElementDescriptor, opts types.FindOptions) (types.FindResult, error) {
+	if ctx == nil {
+		ctx = context.Background()
 	}
+	if err := ctx.Err(); err != nil {
+		return types.FindResult{}, err
+	}
+
+	opts = sanitizeFindOptions(opts, len(elements), 3)
 
 	ef := BuildElementFrequency(elements)
 
@@ -60,7 +65,13 @@ func (m *LexicalMatcher) Find(_ context.Context, query string, elements []types.
 	}
 
 	var candidates []scored
-	for _, el := range elements {
+	for i, el := range elements {
+		if i%64 == 0 {
+			if err := ctx.Err(); err != nil {
+				return types.FindResult{}, err
+			}
+		}
+
 		composite := el.Composite()
 		score := lexicalScore(query, composite, el.Interactive, ef)
 		score += positionalBoost(query, el.Positional)

--- a/internal/engine/lexical_test.go
+++ b/internal/engine/lexical_test.go
@@ -2,11 +2,24 @@ package engine
 
 import (
 	"context"
+	"errors"
 	"github.com/pinchtab/semantic/internal/types"
 	"math"
 	"strconv"
 	"testing"
 )
+
+func TestLexicalMatcher_Find_ContextCanceled(t *testing.T) {
+	m := NewLexicalMatcher()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := m.Find(ctx, "submit button", []types.ElementDescriptor{{Ref: "e1", Role: "button", Name: "Submit"}}, types.FindOptions{Threshold: 0, TopK: 1})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context canceled error, got %v", err)
+	}
+}
 
 func TestTokenPrefixScore_BtnButton(t *testing.T) {
 	// "btn" is NOT a string prefix of "button" (b-t-n vs b-u-t-t-o-n),


### PR DESCRIPTION
## Summary
Adds cancellation-safe matcher execution paths so long-running scoring returns promptly when context is canceled.

## Changes
- Add context cancellation checks in lexical and embedding find loops.
- Add context-aware embedding path for hashing embedder.
- Harden combined matcher concurrent wait path with ctx cancellation select.
- Add high-rigor cancellation regression tests.

## Validation
- go test ./...


## Stack Flow
- PR 32 (base hardening): https://github.com/pinchtab/semantic/pull/32
- PR 33 (runtime cancellation hardening): https://github.com/pinchtab/semantic/pull/33
- PR 34 (adversarial options matrix): https://github.com/pinchtab/semantic/pull/34
