### PR TITLE
feat: add context-aware negative matching

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,12 +58,18 @@ result, err := matcher.Find(ctx, "log in button", elements, semantic.FindOptions
 Queries can include exclusion intent using:
 `not`, `without`, `exclude`, `excluding`, `except`, `no`, `ignore`.
 
+There are two supported patterns:
+- token exclusion, for example `button not submit`
+- context exclusion, for example `submit button not in header`
+
 Examples:
 
 ```text
 button not submit
 link without logout
 textbox excluding email
+submit button not in header
+login link, not the footer one
 ```
 
 CLI examples:

--- a/internal/engine/combined.go
+++ b/internal/engine/combined.go
@@ -44,7 +44,7 @@ func (c *CombinedMatcher) Find(ctx context.Context, query string, elements []typ
 		opts.TopK = 3
 	}
 
-	parsed := ParseQuery(query)
+	parsed := ParseQueryContext(query)
 
 	lexW, embW := c.weights(opts)
 
@@ -68,7 +68,7 @@ type matcherResult struct {
 	err    error
 }
 
-func (c *CombinedMatcher) runBothParsed(ctx context.Context, parsed types.ParsedQuery, elements []types.ElementDescriptor, opts types.FindOptions) (types.FindResult, types.FindResult, error) {
+func (c *CombinedMatcher) runBothParsed(ctx context.Context, parsed QueryContext, elements []types.ElementDescriptor, opts types.FindOptions) (types.FindResult, types.FindResult, error) {
 	internalOpts := types.FindOptions{
 		// Lower threshold allows both strategies to contribute to fusion
 		// before final filtering at the caller's requested threshold.

--- a/internal/engine/embedding.go
+++ b/internal/engine/embedding.go
@@ -49,11 +49,12 @@ func (m *EmbeddingMatcher) Strategy() string {
 }
 
 func (m *EmbeddingMatcher) Find(_ context.Context, query string, elements []types.ElementDescriptor, opts types.FindOptions) (types.FindResult, error) {
-	parsed := ParseQuery(query)
-	return m.findWithParsed(parsed, elements, opts)
+	ctx := ParseQueryContext(query)
+	return m.findWithParsed(ctx, elements, opts)
 }
 
-func (m *EmbeddingMatcher) findWithParsed(parsed types.ParsedQuery, elements []types.ElementDescriptor, opts types.FindOptions) (types.FindResult, error) {
+func (m *EmbeddingMatcher) findWithParsed(ctx QueryContext, elements []types.ElementDescriptor, opts types.FindOptions) (types.FindResult, error) {
+	parsed := ctx.Base
 	if opts.TopK <= 0 {
 		opts.TopK = 3
 	}
@@ -65,17 +66,52 @@ func (m *EmbeddingMatcher) findWithParsed(parsed types.ParsedQuery, elements []t
 		}, nil
 	}
 
+	filtered := filterContextExcludedElements(elements, ctx)
+	if len(filtered) == 0 {
+		return types.FindResult{Strategy: m.Strategy(), ElementCount: len(elements)}, nil
+	}
+
+	vectors, err := m.embedQueryAndElements(parsed, filtered)
+	if err != nil {
+		return types.FindResult{}, err
+	}
+
+	candidates := m.scoreCandidates(parsed, filtered, vectors, opts.Threshold)
+	sort.Slice(candidates, func(i, j int) bool {
+		scoreDiff := candidates[i].score - candidates[j].score
+		if math.Abs(scoreDiff) > 1e-9 {
+			return scoreDiff > 0
+		}
+		return candidates[i].desc.Ref < candidates[j].desc.Ref
+	})
+
+	if len(candidates) > opts.TopK {
+		candidates = candidates[:opts.TopK]
+	}
+
+	return buildEmbeddingResult(m.Strategy(), len(elements), candidates), nil
+}
+
+func filterContextExcludedElements(elements []types.ElementDescriptor, ctx QueryContext) []types.ElementDescriptor {
+	filtered := make([]types.ElementDescriptor, 0, len(elements))
+	for _, el := range elements {
+		if ctx.HasScope && matchesExcludedContext(el, ctx.Exclude) {
+			continue
+		}
+		filtered = append(filtered, el)
+	}
+	return filtered
+}
+
+func (m *EmbeddingMatcher) embedQueryAndElements(parsed types.ParsedQuery, elements []types.ElementDescriptor) ([][]float32, error) {
 	positiveQuery := strings.Join(parsed.Positive, " ")
 	negativeQuery := strings.Join(parsed.Negative, " ")
-	negativeOnly := len(parsed.Positive) == 0 && len(parsed.Negative) > 0
 
-	// Build composite descriptions.
 	descs := make([]string, len(elements))
 	for i, el := range elements {
 		descs[i] = el.Composite()
 	}
 
-	// Embed positive/negative query components and all descriptions in one batch.
 	texts := make([]string, 0, len(descs)+2)
 	if len(parsed.Positive) > 0 {
 		texts = append(texts, positiveQuery)
@@ -84,11 +120,16 @@ func (m *EmbeddingMatcher) findWithParsed(parsed types.ParsedQuery, elements []t
 		texts = append(texts, negativeQuery)
 	}
 	texts = append(texts, descs...)
-	vectors, err := m.embedder.Embed(texts)
-	if err != nil {
-		return types.FindResult{}, err
-	}
+	return m.embedder.Embed(texts)
+}
 
+type embeddingScored struct {
+	desc  types.ElementDescriptor
+	score float64
+}
+
+func (m *EmbeddingMatcher) scoreCandidates(parsed types.ParsedQuery, elements []types.ElementDescriptor, vectors [][]float32, threshold float64) []embeddingScored {
+	negativeOnly := len(parsed.Positive) == 0 && len(parsed.Negative) > 0
 	idx := 0
 	var posVec []float32
 	if len(parsed.Positive) > 0 {
@@ -108,64 +149,50 @@ func (m *EmbeddingMatcher) findWithParsed(parsed types.ParsedQuery, elements []t
 		contextVecs = m.withNeighborContext(elemVecs)
 	}
 
-	type scored struct {
-		desc  types.ElementDescriptor
-		score float64
-	}
-
-	var candidates []scored
+	var candidates []embeddingScored
 	for i, el := range elements {
-		score := 1.0
-		if len(parsed.Positive) > 0 {
-			score = CosineSimilarity(posVec, contextVecs[i])
-		}
-
-		if len(parsed.Negative) > 0 {
-			// Debug note: negSim is the negative-token similarity used to apply
-			// exclusion/down-weight penalties for this candidate.
-			// Negatives should compare against the element vector itself.
-			negSim := CosineSimilarity(negVec, elemVecs[i])
-			if len(parsed.Positive) == 0 {
-				if negSim > 0.5 {
-					score = 0
-				}
-			} else if negSim > 0.5 {
-				score *= 1 - (negSim * 0.8)
-			}
-		}
-
-		if score < 0 {
-			score = 0
-		}
-		if score > 1 {
-			score = 1
-		}
+		score := scoreEmbeddingCandidate(parsed, posVec, negVec, contextVecs[i], elemVecs[i])
 		if negativeOnly && score == 0 {
 			continue
 		}
+		if score >= threshold {
+			candidates = append(candidates, embeddingScored{desc: el, score: score})
+		}
+	}
+	return candidates
+}
 
-		if score >= opts.Threshold {
-			candidates = append(candidates, scored{desc: el, score: score})
+func scoreEmbeddingCandidate(parsed types.ParsedQuery, posVec, negVec, contextVec, elemVec []float32) float64 {
+	score := 1.0
+	if len(parsed.Positive) > 0 {
+		score = CosineSimilarity(posVec, contextVec)
+	}
+
+	if len(parsed.Negative) > 0 {
+		negSim := CosineSimilarity(negVec, elemVec)
+		if len(parsed.Positive) == 0 {
+			if negSim > 0.5 {
+				score = 0
+			}
+		} else if negSim > 0.5 {
+			score *= 1 - (negSim * 0.8)
 		}
 	}
 
-	sort.Slice(candidates, func(i, j int) bool {
-		scoreDiff := candidates[i].score - candidates[j].score
-		if math.Abs(scoreDiff) > 1e-9 {
-			return scoreDiff > 0
-		}
-		return candidates[i].desc.Ref < candidates[j].desc.Ref
-	})
-
-	if len(candidates) > opts.TopK {
-		candidates = candidates[:opts.TopK]
+	if score < 0 {
+		return 0
 	}
+	if score > 1 {
+		return 1
+	}
+	return score
+}
 
+func buildEmbeddingResult(strategy string, elementCount int, candidates []embeddingScored) types.FindResult {
 	result := types.FindResult{
-		Strategy:     m.Strategy(),
-		ElementCount: len(elements),
+		Strategy:     strategy,
+		ElementCount: elementCount,
 	}
-
 	for _, c := range candidates {
 		result.Matches = append(result.Matches, types.ElementMatch{
 			Ref:   c.desc.Ref,
@@ -174,13 +201,11 @@ func (m *EmbeddingMatcher) findWithParsed(parsed types.ParsedQuery, elements []t
 			Name:  c.desc.Name,
 		})
 	}
-
 	if len(result.Matches) > 0 {
 		result.BestRef = result.Matches[0].Ref
 		result.BestScore = result.Matches[0].Score
 	}
-
-	return result, nil
+	return result
 }
 
 func (m *EmbeddingMatcher) withNeighborContext(base [][]float32) [][]float32 {

--- a/internal/engine/lexical.go
+++ b/internal/engine/lexical.go
@@ -48,11 +48,12 @@ func NewLexicalMatcher() *LexicalMatcher {
 func (m *LexicalMatcher) Strategy() string { return "lexical" }
 
 func (m *LexicalMatcher) Find(_ context.Context, query string, elements []types.ElementDescriptor, opts types.FindOptions) (types.FindResult, error) {
-	parsed := ParseQuery(query)
-	return m.findWithParsed(parsed, elements, opts), nil
+	ctx := ParseQueryContext(query)
+	return m.findWithParsed(ctx, elements, opts), nil
 }
 
-func (m *LexicalMatcher) findWithParsed(parsed types.ParsedQuery, elements []types.ElementDescriptor, opts types.FindOptions) types.FindResult {
+func (m *LexicalMatcher) findWithParsed(ctx QueryContext, elements []types.ElementDescriptor, opts types.FindOptions) types.FindResult {
+	parsed := ctx.Base
 	if opts.TopK <= 0 {
 		opts.TopK = 3
 	}
@@ -76,6 +77,10 @@ func (m *LexicalMatcher) findWithParsed(parsed types.ParsedQuery, elements []typ
 
 	var candidates []scored
 	for _, el := range elements {
+		if ctx.HasScope && matchesExcludedContext(el, ctx.Exclude) {
+			continue
+		}
+
 		composite := el.Composite()
 		descTokens := tokenize(composite)
 		score := 0.0

--- a/internal/engine/query_context.go
+++ b/internal/engine/query_context.go
@@ -1,0 +1,168 @@
+package engine
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/pinchtab/semantic/internal/types"
+)
+
+var negativeContextPattern = regexp.MustCompile(`(?i)\b(not|without|exclude|excluding|except|ignore)\b`)
+
+type QueryContext struct {
+	Base     ParsedQuery
+	Exclude  []string
+	HasScope bool
+}
+
+func ParseQueryContext(raw string) QueryContext {
+	parsed := ParseQuery(raw)
+	cleaned := strings.TrimSpace(raw)
+	if cleaned == "" {
+		return QueryContext{Base: parsed}
+	}
+
+	loc := negativeContextPattern.FindStringIndex(cleaned)
+	if loc == nil {
+		return QueryContext{Base: parsed}
+	}
+
+	baseRaw := strings.TrimSpace(cleaned[:loc[0]])
+	remainder := strings.TrimSpace(cleaned[loc[1]:])
+	if baseRaw == "" || remainder == "" {
+		return QueryContext{Base: parsed}
+	}
+
+	baseParsed := ParseQuery(baseRaw)
+	if len(baseParsed.Positive) == 0 {
+		return QueryContext{Base: parsed}
+	}
+	if len(parsed.Negative) == 0 {
+		return QueryContext{Base: parsed}
+	}
+
+	exclude := normalizeContextPhrase(remainder)
+	if len(exclude) == 0 {
+		return QueryContext{Base: parsed}
+	}
+
+	if !looksLikeContextPhrase(exclude) {
+		return QueryContext{Base: parsed}
+	}
+
+	return QueryContext{
+		Base:     baseParsed,
+		Exclude:  exclude,
+		HasScope: true,
+	}
+}
+
+func normalizeContextPhrase(raw string) []string {
+	words := tokenize(strings.Trim(raw, ",.;:- "))
+	if len(words) == 0 {
+		return nil
+	}
+
+	for len(words) > 0 && contextLeadingFillers[words[0]] {
+		words = words[1:]
+	}
+	for len(words) > 0 && contextTrailingFillers[words[len(words)-1]] {
+		words = words[:len(words)-1]
+	}
+	if len(words) == 0 {
+		return nil
+	}
+	return words
+}
+
+func matchesExcludedContext(el types.ElementDescriptor, excludeTokens []string) bool {
+	if len(excludeTokens) == 0 {
+		return false
+	}
+
+	ctxTokens := tokenize(strings.Join([]string{
+		el.Parent,
+		el.Section,
+		el.Positional.LabelledBy,
+		el.Role,
+		el.Name,
+		el.Value,
+	}, " "))
+	if len(ctxTokens) == 0 {
+		return false
+	}
+
+	ctxSet := tokenSet(ctxTokens)
+	matched := 0
+	meaningful := 0
+	for _, tok := range excludeTokens {
+		if isStopword(tok) || isSemanticStopword(tok) {
+			continue
+		}
+		meaningful++
+		if ctxSet[tok] {
+			matched++
+		}
+	}
+	if meaningful == 0 {
+		return false
+	}
+	if matched == meaningful {
+		return true
+	}
+	if meaningful > 1 && float64(matched)/float64(meaningful) >= 0.7 {
+		return true
+	}
+	return false
+}
+
+var contextLeadingFillers = map[string]bool{
+	"in":     true,
+	"on":     true,
+	"at":     true,
+	"of":     true,
+	"to":     true,
+	"from":   true,
+	"inside": true,
+	"within": true,
+	"the":    true,
+	"a":      true,
+	"an":     true,
+}
+
+var contextTrailingFillers = map[string]bool{
+	"one": true,
+}
+
+var contextHintTokens = map[string]bool{
+	"header":     true,
+	"footer":     true,
+	"sidebar":    true,
+	"nav":        true,
+	"navigation": true,
+	"menu":       true,
+	"toolbar":    true,
+	"dialog":     true,
+	"modal":      true,
+	"form":       true,
+	"panel":      true,
+	"section":    true,
+	"content":    true,
+	"main":       true,
+	"top":        true,
+	"bottom":     true,
+	"left":       true,
+	"right":      true,
+	"sticky":     true,
+	"primary":    true,
+	"secondary":  true,
+}
+
+func looksLikeContextPhrase(tokens []string) bool {
+	for _, tok := range tokens {
+		if contextHintTokens[tok] {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/engine/query_context_test.go
+++ b/internal/engine/query_context_test.go
@@ -1,0 +1,164 @@
+package engine
+
+import (
+	"context"
+	"testing"
+
+	"github.com/pinchtab/semantic/internal/types"
+)
+
+func TestParseQueryContext_BasicPatterns(t *testing.T) {
+	tests := []struct {
+		name         string
+		query        string
+		wantPositive []string
+		wantNegative []string
+		wantExclude  []string
+		wantHasScope bool
+	}{
+		{
+			name:         "plain negative tokens",
+			query:        "button not submit",
+			wantPositive: []string{"button"},
+			wantNegative: []string{"submit"},
+		},
+		{
+			name:         "context exclusion in header",
+			query:        "submit button not in header",
+			wantPositive: []string{"submit", "button"},
+			wantExclude:  []string{"header"},
+			wantHasScope: true,
+		},
+		{
+			name:         "context exclusion with filler tail",
+			query:        "login link, not the footer one",
+			wantPositive: []string{"login", "link"},
+			wantExclude:  []string{"footer"},
+			wantHasScope: true,
+		},
+		{
+			name:         "excluding sidebar",
+			query:        "search box excluding sidebar",
+			wantPositive: []string{"search", "box"},
+			wantExclude:  []string{"sidebar"},
+			wantHasScope: true,
+		},
+		{
+			name:         "leading not stays literal",
+			query:        "not now button",
+			wantPositive: []string{"not", "now", "button"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ParseQueryContext(tt.query)
+			assertTokens(t, got.Base.Positive, tt.wantPositive, "positive")
+			assertTokens(t, got.Base.Negative, tt.wantNegative, "negative")
+			assertTokens(t, got.Exclude, tt.wantExclude, "exclude")
+			if got.HasScope != tt.wantHasScope {
+				t.Fatalf("HasScope mismatch: got=%v want=%v", got.HasScope, tt.wantHasScope)
+			}
+		})
+	}
+}
+
+func TestMatchesExcludedContext(t *testing.T) {
+	el := types.ElementDescriptor{
+		Ref:     "e1",
+		Role:    "button",
+		Name:    "Submit",
+		Parent:  "Account Header",
+		Section: "Top Header Actions",
+		Positional: types.PositionalHints{
+			LabelledBy: "Header controls",
+		},
+	}
+
+	if !matchesExcludedContext(el, []string{"header"}) {
+		t.Fatalf("expected header exclusion to match")
+	}
+	if !matchesExcludedContext(el, []string{"top", "header"}) {
+		t.Fatalf("expected multi-token exclusion to match")
+	}
+	if matchesExcludedContext(el, []string{"sidebar"}) {
+		t.Fatalf("did not expect unrelated exclusion to match")
+	}
+}
+
+func TestNegativeContextAcrossMatchers(t *testing.T) {
+	elements := []types.ElementDescriptor{
+		{Ref: "header-submit", Role: "button", Name: "Submit", Section: "Header"},
+		{Ref: "main-submit", Role: "button", Name: "Submit", Section: "Checkout content"},
+		{Ref: "footer-submit", Role: "button", Name: "Submit", Section: "Footer"},
+	}
+
+	queries := []string{
+		"submit button not in header",
+		"submit button except footer",
+	}
+
+	matchers := []types.ElementMatcher{
+		NewLexicalMatcher(),
+		NewEmbeddingMatcher(NewHashingEmbedder(128)),
+		NewCombinedMatcher(NewHashingEmbedder(128)),
+	}
+
+	for _, matcher := range matchers {
+		for _, query := range queries {
+			res, err := matcher.Find(context.Background(), query, elements, types.FindOptions{Threshold: 0, TopK: 3})
+			if err != nil {
+				t.Fatalf("%s Find failed for %q: %v", matcher.Strategy(), query, err)
+			}
+			for _, match := range res.Matches {
+				if query == "submit button not in header" && match.Ref == "header-submit" {
+					t.Fatalf("%s should exclude header match for %q", matcher.Strategy(), query)
+				}
+				if query == "submit button except footer" && match.Ref == "footer-submit" {
+					t.Fatalf("%s should exclude footer match for %q", matcher.Strategy(), query)
+				}
+			}
+		}
+	}
+}
+
+func TestDuplicateRegionDisambiguation(t *testing.T) {
+	m := NewCombinedMatcher(NewHashingEmbedder(128))
+	elements := []types.ElementDescriptor{
+		{Ref: "login-header", Role: "link", Name: "Log in", Section: "Header"},
+		{Ref: "login-footer", Role: "link", Name: "Log in", Section: "Footer"},
+		{Ref: "login-sidebar", Role: "link", Name: "Log in", Section: "Sticky Sidebar Quick Actions"},
+	}
+
+	res, err := m.Find(context.Background(), "login link, not the footer one", elements, types.FindOptions{Threshold: 0, TopK: 3})
+	if err != nil {
+		t.Fatalf("Find failed: %v", err)
+	}
+	for _, match := range res.Matches {
+		if match.Ref == "login-footer" {
+			t.Fatalf("expected footer variant to be excluded")
+		}
+	}
+
+	res2, err := m.Find(context.Background(), "login link except sticky sidebar quick actions", elements, types.FindOptions{Threshold: 0, TopK: 3})
+	if err != nil {
+		t.Fatalf("Find failed: %v", err)
+	}
+	for _, match := range res2.Matches {
+		if match.Ref == "login-sidebar" {
+			t.Fatalf("expected sidebar variant to be excluded")
+		}
+	}
+}
+
+func assertTokens(t *testing.T, got, want []string, label string) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("%s length mismatch: got=%v want=%v", label, got, want)
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			t.Fatalf("%s mismatch: got=%v want=%v", label, got, want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- add context-aware negative matching for region disambiguation
- support queries like `submit button not in header` and `login link, not the footer one`
- keep existing token-level negative matching behavior intact
- add cross-matcher tests and update README docs

## Why
PR #28 added token-level negative matching, but duplicate elements across page regions still need context-aware exclusion.

This follow-up brings over the good ideas from the earlier approach while integrating them cleanly with the current parser and matcher design.

## Notes
- This PR supersedes #29
- #29 explored the same problem space, but this branch is built on top of merged negative matching and keeps the newer query parsing model

Supersedes: #29
