### PR TITLE
feat: support ordinal queries (first/second/last)

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ result, err := matcher.Find(ctx, "log in button", elements, semantic.FindOptions
 // result.BestScore = 0.82
 ```
 
-## Negative Queries
+## Negative and Ordinal Queries
 
 Queries can include exclusion intent using:
 `not`, `without`, `exclude`, `excluding`, `except`, `no`, `ignore`.
@@ -80,12 +80,22 @@ semantic find "link without logout" --snapshot page.json
 semantic find "textbox not email" --snapshot page.json --strategy combined
 ```
 
+Ordinal queries are also supported for position-based selection:
+
+```text
+second button
+third menu item
+last input field
+```
+
 Behavior:
 
 - Positive tokens contribute to base match score.
 - Negative tokens apply penalty when they match an element.
 - Strong negative hits can fully exclude an element from results.
 - Negative matching is synonym-aware (for example, `not login` can penalize `Sign In`).
+- Ordinals select from the final matching candidates in document order.
+- Ordinals compose with context exclusion, for example `second button not in header`.
 
 ## Package Layout
 

--- a/cmd/semantic/main.go
+++ b/cmd/semantic/main.go
@@ -135,6 +135,7 @@ func loadSnapshot(path string) ([]semantic.ElementDescriptor, error) {
 			Interactive: e.Interactive,
 			Parent:      e.Parent,
 			Section:     e.Section,
+			DocumentIdx: i,
 			Positional: semantic.PositionalHints{
 				Depth:        depth,
 				SiblingIndex: siblingIdx,

--- a/dev
+++ b/dev
@@ -21,7 +21,7 @@ commands=(
   "vet:🔬:Run go vet"
   "check:✅:Run all checks (fmt + vet + lint + test)"
   "build:📦:Build CLI binary"
-  "benchmark:🏋:Run benchmark study"
+  "bench:🏋:Run corpus benchmark suite"
   "e2e:🐳:Run E2E tests (Docker)"
 )
 
@@ -114,9 +114,9 @@ run_build() {
   echo "  ${SUCCESS}✓${NC} Built: ./semantic"
 }
 
-run_benchmark() {
-  echo "  ${ACCENT}${BOLD}⏱️  Running benchmark study${NC}"
-  go test -run TestBenchmarkStudy -v -count=1
+run_bench() {
+  echo "  ${ACCENT}${BOLD}⏱️  Running corpus benchmark suite${NC}"
+  bash tests/benchmark/scripts/run-corpus-benchmark.sh
 }
 
 run_e2e() {
@@ -143,7 +143,7 @@ case "${1:-help}" in
   vet)       run_vet ;;
   check)     run_check ;;
   build)     run_build ;;
-  benchmark) run_benchmark ;;
+  bench|benchmark) run_bench ;;
   e2e)       run_e2e ;;
   help|*)    show_help ;;
 esac

--- a/docs/guides/contributing.md
+++ b/docs/guides/contributing.md
@@ -19,7 +19,7 @@ Doctor checks Go version, golangci-lint, dependencies, build, tests, and git hoo
 ./dev lint          # golangci-lint
 ./dev check         # all checks (fmt + vet + lint + test)
 ./dev build         # build CLI binary
-./dev benchmark     # run benchmark study
+./dev bench         # run corpus benchmark suite
 ```
 
 ## Project Structure

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -33,6 +33,15 @@ semantic find "login" --snapshot page.json --format json
 
 # Just refs (for piping)
 semantic find "submit" --snapshot page.json --format refs
+
+# Exclude contexts for duplicate labels
+semantic find "submit button not in header" --snapshot page.json
+semantic find "login link, not the footer one" --snapshot page.json
+
+# Select by ordinal position
+semantic find "second button" --snapshot page.json
+semantic find "last input field" --snapshot page.json
+semantic find "second button not in header" --snapshot page.json
 ```
 
 ### `semantic match`

--- a/internal/engine/combined.go
+++ b/internal/engine/combined.go
@@ -209,10 +209,10 @@ func (c *CombinedMatcher) mergeResults(lexResult, embResult types.FindResult, el
 }
 
 func documentOrderIndex(el types.ElementDescriptor, fallback int) int {
-	if el.DocumentIdx > 0 || (el.DocumentIdx == 0 && el.Ref != "") {
+	if el.DocumentIdx > 0 {
 		return el.DocumentIdx
 	}
-	if el.Positional.SiblingIndex > 0 || (el.Positional.SiblingIndex == 0 && el.Ref != "") {
+	if el.Positional.SiblingIndex > 0 {
 		return el.Positional.SiblingIndex
 	}
 	return fallback

--- a/internal/engine/combined.go
+++ b/internal/engine/combined.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"github.com/pinchtab/semantic/internal/types"
+	"math"
 	"sort"
 )
 
@@ -45,6 +46,10 @@ func (c *CombinedMatcher) Find(ctx context.Context, query string, elements []typ
 	}
 
 	parsed := ParseQueryContext(query)
+	mergeOpts := opts
+	if parsed.Ordinal.HasOrdinal {
+		mergeOpts.TopK = len(elements)
+	}
 
 	lexW, embW := c.weights(opts)
 
@@ -53,7 +58,8 @@ func (c *CombinedMatcher) Find(ctx context.Context, query string, elements []typ
 		return types.FindResult{}, err
 	}
 
-	return c.mergeResults(lexResult, embResult, elements, opts, lexW, embW), nil
+	merged := c.mergeResults(lexResult, embResult, elements, mergeOpts, lexW, embW)
+	return selectOrdinalMatchInOrder(merged, parsed.Ordinal, elements), nil
 }
 
 func (c *CombinedMatcher) weights(opts types.FindOptions) (float64, float64) {
@@ -156,7 +162,18 @@ func (c *CombinedMatcher) mergeResults(lexResult, embResult types.FindResult, el
 	}
 
 	sort.Slice(candidates, func(i, j int) bool {
-		return candidates[i].score > candidates[j].score
+		scoreDiff := candidates[i].score - candidates[j].score
+		if math.Abs(scoreDiff) > 1e-9 {
+			return scoreDiff > 0
+		}
+
+		idxI := candidates[i].el.Positional.SiblingIndex
+		idxJ := candidates[j].el.Positional.SiblingIndex
+		if idxI != idxJ {
+			return idxI < idxJ
+		}
+
+		return candidates[i].ref < candidates[j].ref
 	})
 	if len(candidates) > opts.TopK {
 		candidates = candidates[:opts.TopK]

--- a/internal/engine/combined.go
+++ b/internal/engine/combined.go
@@ -47,13 +47,15 @@ func (c *CombinedMatcher) Find(ctx context.Context, query string, elements []typ
 
 	parsed := ParseQueryContext(query)
 	mergeOpts := opts
+	internalOpts := opts
 	if parsed.Ordinal.HasOrdinal {
 		mergeOpts.TopK = len(elements)
+		internalOpts.TopK = len(elements)
 	}
 
 	lexW, embW := c.weights(opts)
 
-	lexResult, embResult, err := c.runBothParsed(ctx, parsed, elements, opts)
+	lexResult, embResult, err := c.runBothParsed(ctx, parsed, elements, internalOpts)
 	if err != nil {
 		return types.FindResult{}, err
 	}
@@ -167,8 +169,8 @@ func (c *CombinedMatcher) mergeResults(lexResult, embResult types.FindResult, el
 			return scoreDiff > 0
 		}
 
-		idxI := candidates[i].el.Positional.SiblingIndex
-		idxJ := candidates[j].el.Positional.SiblingIndex
+		idxI := documentOrderIndex(candidates[i].el, i)
+		idxJ := documentOrderIndex(candidates[j].el, j)
 		if idxI != idxJ {
 			return idxI < idxJ
 		}
@@ -204,6 +206,16 @@ func (c *CombinedMatcher) mergeResults(lexResult, embResult types.FindResult, el
 		result.BestScore = result.Matches[0].Score
 	}
 	return result
+}
+
+func documentOrderIndex(el types.ElementDescriptor, fallback int) int {
+	if el.DocumentIdx > 0 || (el.DocumentIdx == 0 && el.Ref != "") {
+		return el.DocumentIdx
+	}
+	if el.Positional.SiblingIndex > 0 || (el.Positional.SiblingIndex == 0 && el.Ref != "") {
+		return el.Positional.SiblingIndex
+	}
+	return fallback
 }
 
 func scoreMap(matches []types.ElementMatch) map[string]float64 {

--- a/internal/engine/query_context.go
+++ b/internal/engine/query_context.go
@@ -13,47 +13,50 @@ type QueryContext struct {
 	Base     ParsedQuery
 	Exclude  []string
 	HasScope bool
+	Ordinal  OrdinalConstraint
 }
 
 func ParseQueryContext(raw string) QueryContext {
-	parsed := ParseQuery(raw)
-	cleaned := strings.TrimSpace(raw)
+	ordinal, baseRaw := parseOrdinalConstraint(raw)
+	parsed := ParseQuery(baseRaw)
+	cleaned := strings.TrimSpace(baseRaw)
 	if cleaned == "" {
-		return QueryContext{Base: parsed}
+		return QueryContext{Base: parsed, Ordinal: ordinal}
 	}
 
 	loc := negativeContextPattern.FindStringIndex(cleaned)
 	if loc == nil {
-		return QueryContext{Base: parsed}
+		return QueryContext{Base: parsed, Ordinal: ordinal}
 	}
 
-	baseRaw := strings.TrimSpace(cleaned[:loc[0]])
+	contextBaseRaw := strings.TrimSpace(cleaned[:loc[0]])
 	remainder := strings.TrimSpace(cleaned[loc[1]:])
-	if baseRaw == "" || remainder == "" {
-		return QueryContext{Base: parsed}
+	if contextBaseRaw == "" || remainder == "" {
+		return QueryContext{Base: parsed, Ordinal: ordinal}
 	}
 
-	baseParsed := ParseQuery(baseRaw)
+	baseParsed := ParseQuery(contextBaseRaw)
 	if len(baseParsed.Positive) == 0 {
-		return QueryContext{Base: parsed}
+		return QueryContext{Base: parsed, Ordinal: ordinal}
 	}
 	if len(parsed.Negative) == 0 {
-		return QueryContext{Base: parsed}
+		return QueryContext{Base: parsed, Ordinal: ordinal}
 	}
 
 	exclude := normalizeContextPhrase(remainder)
 	if len(exclude) == 0 {
-		return QueryContext{Base: parsed}
+		return QueryContext{Base: parsed, Ordinal: ordinal}
 	}
 
 	if !looksLikeContextPhrase(exclude) {
-		return QueryContext{Base: parsed}
+		return QueryContext{Base: parsed, Ordinal: ordinal}
 	}
 
 	return QueryContext{
 		Base:     baseParsed,
 		Exclude:  exclude,
 		HasScope: true,
+		Ordinal:  ordinal,
 	}
 }
 

--- a/internal/engine/query_ordinal.go
+++ b/internal/engine/query_ordinal.go
@@ -153,7 +153,11 @@ func selectOrdinalMatchInOrder(result types.FindResult, constraint OrdinalConstr
 
 	refOrder := make(map[string]int, len(elements))
 	for idx, el := range elements {
-		refOrder[el.Ref] = idx
+		order := el.DocumentIdx
+		if order < 0 {
+			order = idx
+		}
+		refOrder[el.Ref] = order
 	}
 
 	ordered := make([]types.ElementMatch, len(filtered))
@@ -203,7 +207,7 @@ func filterOrdinalCandidates(matches []types.ElementMatch) []types.ElementMatch 
 		}
 	}
 
-	floor := bestScore * 0.75
+	floor := bestScore - 0.15
 	if floor < 0.2 {
 		floor = 0.2
 	}

--- a/internal/engine/query_ordinal.go
+++ b/internal/engine/query_ordinal.go
@@ -1,0 +1,184 @@
+package engine
+
+import (
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/pinchtab/semantic/internal/types"
+)
+
+type OrdinalConstraint struct {
+	HasOrdinal bool
+	Last       bool
+	Position   int
+}
+
+var numericOrdinalPattern = regexp.MustCompile(`^(\d+)(st|nd|rd|th)$`)
+
+var ordinalWords = map[string]int{
+	"first":   1,
+	"second":  2,
+	"third":   3,
+	"fourth":  4,
+	"fifth":   5,
+	"sixth":   6,
+	"seventh": 7,
+	"eighth":  8,
+	"ninth":   9,
+	"tenth":   10,
+}
+
+var ordinalTargetWords = map[string]bool{
+	"button":    true,
+	"link":      true,
+	"input":     true,
+	"field":     true,
+	"textbox":   true,
+	"searchbox": true,
+	"item":      true,
+	"menu":      true,
+	"option":    true,
+	"tab":       true,
+	"result":    true,
+	"row":       true,
+	"column":    true,
+	"card":      true,
+	"entry":     true,
+	"element":   true,
+}
+
+func parseNumericOrdinal(token string) (int, bool) {
+	m := numericOrdinalPattern.FindStringSubmatch(token)
+	if len(m) != 3 {
+		return 0, false
+	}
+	n, err := strconv.Atoi(m[1])
+	if err != nil || n <= 0 {
+		return 0, false
+	}
+	return n, true
+}
+
+func normalizeQueryToken(token string) string {
+	return strings.Trim(strings.ToLower(token), ",.;:-")
+}
+
+func containsOrdinalTarget(words []string, ordIdx int) bool {
+	for i, w := range words {
+		if i == ordIdx {
+			continue
+		}
+		if ordinalTargetWords[normalizeQueryToken(w)] {
+			return true
+		}
+	}
+	return false
+}
+
+func parseOrdinalConstraint(query string) (OrdinalConstraint, string) {
+	cleaned := strings.TrimSpace(query)
+	if cleaned == "" {
+		return OrdinalConstraint{}, cleaned
+	}
+
+	words := strings.Fields(cleaned)
+	if len(words) == 0 {
+		return OrdinalConstraint{}, cleaned
+	}
+
+	ordIdx := -1
+	ordPos := 0
+	ordLast := false
+
+	for i, w := range words {
+		norm := normalizeQueryToken(w)
+		if norm == "" {
+			continue
+		}
+		if norm == "last" || norm == "final" {
+			ordIdx = i
+			ordLast = true
+			break
+		}
+		if pos, ok := ordinalWords[norm]; ok {
+			ordIdx = i
+			ordPos = pos
+			break
+		}
+		if pos, ok := parseNumericOrdinal(norm); ok {
+			ordIdx = i
+			ordPos = pos
+			break
+		}
+	}
+
+	if ordIdx == -1 || !containsOrdinalTarget(words, ordIdx) {
+		return OrdinalConstraint{}, cleaned
+	}
+
+	filtered := make([]string, 0, len(words)-1)
+	for i, w := range words {
+		if i == ordIdx {
+			continue
+		}
+		filtered = append(filtered, w)
+	}
+
+	base := strings.Trim(strings.TrimSpace(strings.Join(filtered, " ")), ",.;:-")
+	if base == "" {
+		base = cleaned
+	}
+
+	return OrdinalConstraint{
+		HasOrdinal: true,
+		Last:       ordLast,
+		Position:   ordPos,
+	}, base
+}
+
+func selectOrdinalMatchInOrder(result types.FindResult, constraint OrdinalConstraint, elements []types.ElementDescriptor) types.FindResult {
+	if !constraint.HasOrdinal || len(result.Matches) == 0 {
+		return result
+	}
+
+	refOrder := make(map[string]int, len(elements))
+	for idx, el := range elements {
+		refOrder[el.Ref] = idx
+	}
+
+	ordered := make([]types.ElementMatch, len(result.Matches))
+	copy(ordered, result.Matches)
+	sort.SliceStable(ordered, func(i, j int) bool {
+		idxI, okI := refOrder[ordered[i].Ref]
+		idxJ, okJ := refOrder[ordered[j].Ref]
+		if okI && okJ {
+			return idxI < idxJ
+		}
+		if okI != okJ {
+			return okI
+		}
+		return ordered[i].Ref < ordered[j].Ref
+	})
+
+	idx := -1
+	if constraint.Last {
+		idx = len(ordered) - 1
+	} else if constraint.Position > 0 {
+		idx = constraint.Position - 1
+	}
+
+	if idx < 0 || idx >= len(ordered) {
+		result.Matches = nil
+		result.BestRef = ""
+		result.BestScore = 0
+		return result
+	}
+
+	chosen := ordered[idx]
+	result.Matches = []types.ElementMatch{chosen}
+	result.BestRef = chosen.Ref
+	result.BestScore = chosen.Score
+	return result
+}

--- a/internal/engine/query_ordinal.go
+++ b/internal/engine/query_ordinal.go
@@ -143,13 +143,21 @@ func selectOrdinalMatchInOrder(result types.FindResult, constraint OrdinalConstr
 		return result
 	}
 
+	filtered := filterOrdinalCandidates(result.Matches)
+	if len(filtered) == 0 {
+		result.Matches = nil
+		result.BestRef = ""
+		result.BestScore = 0
+		return result
+	}
+
 	refOrder := make(map[string]int, len(elements))
 	for idx, el := range elements {
 		refOrder[el.Ref] = idx
 	}
 
-	ordered := make([]types.ElementMatch, len(result.Matches))
-	copy(ordered, result.Matches)
+	ordered := make([]types.ElementMatch, len(filtered))
+	copy(ordered, filtered)
 	sort.SliceStable(ordered, func(i, j int) bool {
 		idxI, okI := refOrder[ordered[i].Ref]
 		idxJ, okJ := refOrder[ordered[j].Ref]
@@ -181,4 +189,30 @@ func selectOrdinalMatchInOrder(result types.FindResult, constraint OrdinalConstr
 	result.BestRef = chosen.Ref
 	result.BestScore = chosen.Score
 	return result
+}
+
+func filterOrdinalCandidates(matches []types.ElementMatch) []types.ElementMatch {
+	if len(matches) == 0 {
+		return nil
+	}
+
+	bestScore := matches[0].Score
+	for _, match := range matches[1:] {
+		if match.Score > bestScore {
+			bestScore = match.Score
+		}
+	}
+
+	floor := bestScore * 0.75
+	if floor < 0.2 {
+		floor = 0.2
+	}
+
+	filtered := make([]types.ElementMatch, 0, len(matches))
+	for _, match := range matches {
+		if match.Score >= floor {
+			filtered = append(filtered, match)
+		}
+	}
+	return filtered
 }

--- a/internal/engine/query_ordinal_test.go
+++ b/internal/engine/query_ordinal_test.go
@@ -100,9 +100,9 @@ func TestCombinedMatcher_OrdinalQuery_SecondButton(t *testing.T) {
 func TestCombinedMatcher_OrdinalQuery_LastInputField(t *testing.T) {
 	m := NewCombinedMatcher(NewHashingEmbedder(128))
 	elements := []types.ElementDescriptor{
-		{Ref: "input-1", Role: "textbox", Name: "Email", Positional: types.PositionalHints{SiblingIndex: 0}},
-		{Ref: "input-2", Role: "textbox", Name: "Email", Positional: types.PositionalHints{SiblingIndex: 1}},
-		{Ref: "input-3", Role: "textbox", Name: "Email", Positional: types.PositionalHints{SiblingIndex: 2}},
+		{Ref: "input-1", Role: "textbox", Name: "Email", DocumentIdx: 0, Positional: types.PositionalHints{SiblingIndex: 1}},
+		{Ref: "input-2", Role: "textbox", Name: "Email", DocumentIdx: 1, Positional: types.PositionalHints{SiblingIndex: 2}},
+		{Ref: "input-3", Role: "textbox", Name: "Email", DocumentIdx: 2, Positional: types.PositionalHints{SiblingIndex: 3}},
 	}
 
 	res, err := m.Find(context.Background(), "last input field", elements, types.FindOptions{Threshold: 0, TopK: 3})

--- a/internal/engine/query_ordinal_test.go
+++ b/internal/engine/query_ordinal_test.go
@@ -175,3 +175,36 @@ func TestCombinedMatcher_OrdinalWithContextExclusion(t *testing.T) {
 		t.Fatalf("expected second non-header button, got %s", res.BestRef)
 	}
 }
+
+func TestFilterOrdinalCandidates_DropsWeakSemanticTail(t *testing.T) {
+	matches := []types.ElementMatch{
+		{Ref: "e1", Score: 0.92},
+		{Ref: "e2", Score: 0.81},
+		{Ref: "e3", Score: 0.18},
+	}
+
+	filtered := filterOrdinalCandidates(matches)
+	if len(filtered) != 2 {
+		t.Fatalf("expected 2 strong candidates, got %d", len(filtered))
+	}
+	if filtered[0].Ref != "e1" || filtered[1].Ref != "e2" {
+		t.Fatalf("unexpected filtered refs: %+v", filtered)
+	}
+}
+
+func TestCombinedMatcher_OrdinalQuery_IgnoresWeakNonButtonTail(t *testing.T) {
+	m := NewCombinedMatcher(NewHashingEmbedder(128))
+	elements := []types.ElementDescriptor{
+		{Ref: "btn-1", Role: "button", Name: "Submit", Positional: types.PositionalHints{SiblingIndex: 0}},
+		{Ref: "btn-2", Role: "button", Name: "Submit", Positional: types.PositionalHints{SiblingIndex: 1}},
+		{Ref: "note", Role: "note", Name: "Submission tips", Positional: types.PositionalHints{SiblingIndex: 2}},
+	}
+
+	res, err := m.Find(context.Background(), "second submit button", elements, types.FindOptions{Threshold: 0, TopK: 3})
+	if err != nil {
+		t.Fatalf("Find failed: %v", err)
+	}
+	if res.BestRef != "btn-2" {
+		t.Fatalf("expected second submit button btn-2, got %s", res.BestRef)
+	}
+}

--- a/internal/engine/query_ordinal_test.go
+++ b/internal/engine/query_ordinal_test.go
@@ -1,0 +1,177 @@
+package engine
+
+import (
+	"context"
+	"testing"
+
+	"github.com/pinchtab/semantic/internal/types"
+)
+
+func TestParseOrdinalConstraint_BasicPatterns(t *testing.T) {
+	tests := []struct {
+		name       string
+		query      string
+		wantBase   string
+		wantHasOrd bool
+		wantPos    int
+		wantIsLast bool
+	}{
+		{
+			name:       "second button",
+			query:      "second button",
+			wantBase:   "button",
+			wantHasOrd: true,
+			wantPos:    2,
+		},
+		{
+			name:       "numeric ordinal",
+			query:      "3rd menu item",
+			wantBase:   "menu item",
+			wantHasOrd: true,
+			wantPos:    3,
+		},
+		{
+			name:       "last input field",
+			query:      "last input field",
+			wantBase:   "input field",
+			wantHasOrd: true,
+			wantIsLast: true,
+		},
+		{
+			name:       "non ordinal content query",
+			query:      "first name",
+			wantBase:   "first name",
+			wantHasOrd: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, base := parseOrdinalConstraint(tt.query)
+			if base != tt.wantBase {
+				t.Fatalf("base query mismatch: want=%q got=%q", tt.wantBase, base)
+			}
+			if got.HasOrdinal != tt.wantHasOrd {
+				t.Fatalf("HasOrdinal mismatch: want=%v got=%v", tt.wantHasOrd, got.HasOrdinal)
+			}
+			if got.Position != tt.wantPos {
+				t.Fatalf("position mismatch: want=%d got=%d", tt.wantPos, got.Position)
+			}
+			if got.Last != tt.wantIsLast {
+				t.Fatalf("last mismatch: want=%v got=%v", tt.wantIsLast, got.Last)
+			}
+		})
+	}
+}
+
+func TestParseQueryContext_WithOrdinalAndNegativeScope(t *testing.T) {
+	ctx := ParseQueryContext("second button not in header")
+	if !ctx.Ordinal.HasOrdinal || ctx.Ordinal.Position != 2 {
+		t.Fatalf("expected second ordinal, got %+v", ctx.Ordinal)
+	}
+	assertTokens(t, ctx.Base.Positive, []string{"button"}, "positive")
+	assertTokens(t, ctx.Base.Negative, []string{}, "negative")
+	assertTokens(t, ctx.Exclude, []string{"header"}, "exclude")
+	if !ctx.HasScope {
+		t.Fatalf("expected scope exclusion to be detected")
+	}
+}
+
+func TestCombinedMatcher_OrdinalQuery_SecondButton(t *testing.T) {
+	m := NewCombinedMatcher(NewHashingEmbedder(128))
+	elements := []types.ElementDescriptor{
+		{Ref: "btn-1", Role: "button", Name: "Action", Positional: types.PositionalHints{SiblingIndex: 0}},
+		{Ref: "btn-2", Role: "button", Name: "Action", Positional: types.PositionalHints{SiblingIndex: 1}},
+		{Ref: "btn-3", Role: "button", Name: "Action", Positional: types.PositionalHints{SiblingIndex: 2}},
+	}
+
+	res, err := m.Find(context.Background(), "second button", elements, types.FindOptions{Threshold: 0, TopK: 3})
+	if err != nil {
+		t.Fatalf("Find failed: %v", err)
+	}
+	if len(res.Matches) != 1 {
+		t.Fatalf("expected one ordinal-selected match, got %d", len(res.Matches))
+	}
+	if res.BestRef != "btn-2" {
+		t.Fatalf("expected second button btn-2, got %s", res.BestRef)
+	}
+}
+
+func TestCombinedMatcher_OrdinalQuery_LastInputField(t *testing.T) {
+	m := NewCombinedMatcher(NewHashingEmbedder(128))
+	elements := []types.ElementDescriptor{
+		{Ref: "input-1", Role: "textbox", Name: "Email", Positional: types.PositionalHints{SiblingIndex: 0}},
+		{Ref: "input-2", Role: "textbox", Name: "Email", Positional: types.PositionalHints{SiblingIndex: 1}},
+		{Ref: "input-3", Role: "textbox", Name: "Email", Positional: types.PositionalHints{SiblingIndex: 2}},
+	}
+
+	res, err := m.Find(context.Background(), "last input field", elements, types.FindOptions{Threshold: 0, TopK: 3})
+	if err != nil {
+		t.Fatalf("Find failed: %v", err)
+	}
+	if len(res.Matches) != 1 {
+		t.Fatalf("expected one ordinal-selected match, got %d", len(res.Matches))
+	}
+	if res.BestRef != "input-3" {
+		t.Fatalf("expected last input field input-3, got %s", res.BestRef)
+	}
+}
+
+func TestCombinedMatcher_OrdinalQuery_OutOfRangeReturnsNoMatch(t *testing.T) {
+	m := NewCombinedMatcher(NewHashingEmbedder(128))
+	elements := []types.ElementDescriptor{
+		{Ref: "b1", Role: "button", Name: "Continue", Positional: types.PositionalHints{SiblingIndex: 0}},
+		{Ref: "b2", Role: "button", Name: "Continue", Positional: types.PositionalHints{SiblingIndex: 1}},
+		{Ref: "b3", Role: "button", Name: "Continue", Positional: types.PositionalHints{SiblingIndex: 2}},
+	}
+
+	res, err := m.Find(context.Background(), "fifth button", elements, types.FindOptions{Threshold: 0, TopK: 3})
+	if err != nil {
+		t.Fatalf("Find failed: %v", err)
+	}
+	if len(res.Matches) != 0 {
+		t.Fatalf("expected no matches for out-of-range ordinal, got %d", len(res.Matches))
+	}
+	if res.BestRef != "" || res.BestScore != 0 {
+		t.Fatalf("expected empty best match for out-of-range ordinal, got ref=%q score=%f", res.BestRef, res.BestScore)
+	}
+}
+
+func TestCombinedMatcher_OrdinalGuard_DoesNotTreatFirstNameAsOrdinal(t *testing.T) {
+	m := NewCombinedMatcher(NewHashingEmbedder(128))
+	elements := []types.ElementDescriptor{
+		{Ref: "first-name", Role: "textbox", Name: "First Name", Positional: types.PositionalHints{SiblingIndex: 3}},
+		{Ref: "last-name", Role: "textbox", Name: "Last Name", Positional: types.PositionalHints{SiblingIndex: 0}},
+	}
+
+	res, err := m.Find(context.Background(), "first name", elements, types.FindOptions{Threshold: 0, TopK: 2})
+	if err != nil {
+		t.Fatalf("Find failed: %v", err)
+	}
+	if len(res.Matches) == 0 {
+		t.Fatalf("expected at least one match")
+	}
+	if res.BestRef != "first-name" {
+		t.Fatalf("expected semantic match for 'first name', got %s", res.BestRef)
+	}
+}
+
+func TestCombinedMatcher_OrdinalWithContextExclusion(t *testing.T) {
+	m := NewCombinedMatcher(NewHashingEmbedder(128))
+	elements := []types.ElementDescriptor{
+		{Ref: "header-btn", Role: "button", Name: "Submit", Section: "Header", Positional: types.PositionalHints{SiblingIndex: 0}},
+		{Ref: "main-btn-1", Role: "button", Name: "Submit", Section: "Main", Positional: types.PositionalHints{SiblingIndex: 1}},
+		{Ref: "main-btn-2", Role: "button", Name: "Submit", Section: "Main", Positional: types.PositionalHints{SiblingIndex: 2}},
+	}
+
+	res, err := m.Find(context.Background(), "second button not in header", elements, types.FindOptions{Threshold: 0, TopK: 3})
+	if err != nil {
+		t.Fatalf("Find failed: %v", err)
+	}
+	if len(res.Matches) != 1 {
+		t.Fatalf("expected one ordinal-selected match, got %d", len(res.Matches))
+	}
+	if res.BestRef != "main-btn-2" {
+		t.Fatalf("expected second non-header button, got %s", res.BestRef)
+	}
+}

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -100,6 +100,7 @@ type ElementDescriptor struct {
 	Interactive bool
 	Parent      string
 	Section     string
+	DocumentIdx int
 	Positional  PositionalHints
 }
 

--- a/skills/semantic-dev/SKILL.md
+++ b/skills/semantic-dev/SKILL.md
@@ -29,7 +29,7 @@ All development commands run via `./dev`:
 | `./dev vet` | Run go vet |
 | `./dev check` | All checks (fmt + vet + lint + test) |
 | `./dev build` | Build CLI binary |
-| `./dev benchmark` | Run benchmark study |
+| `./dev bench` | Run corpus benchmark suite |
 | `./dev e2e` | Run E2E tests (Docker) |
 
 ## Architecture
@@ -112,7 +112,7 @@ recovery.ClassifyFailure, recovery.DefaultRecoveryConfig
 ## Testing
 
 - **167 tests** across 3 packages (root, engine, recovery)
-- `internal/engine/` has unit tests for all matchers + benchmark study
+- `internal/engine/` has unit tests for all matchers + benchmark suite
 - Root has API-level smoke tests
 - `recovery/` has scenario tests (SPA re-render, checkout, login, etc.)
 

--- a/tests/benchmark/corpus/ordinal-context/queries.json
+++ b/tests/benchmark/corpus/ordinal-context/queries.json
@@ -1,0 +1,44 @@
+[
+  {
+    "id": "ordinal-001",
+    "query": "second submit button",
+    "relevant_refs": ["e2"],
+    "partially_relevant_refs": [],
+    "difficulty": "medium",
+    "tags": ["ordinal", "button", "duplicate-labels"]
+  },
+  {
+    "id": "ordinal-002",
+    "query": "last submit button",
+    "relevant_refs": ["e4"],
+    "partially_relevant_refs": [],
+    "difficulty": "medium",
+    "tags": ["ordinal", "button", "duplicate-labels"]
+  },
+  {
+    "id": "ordinal-003",
+    "query": "second submit button not in header",
+    "relevant_refs": ["e3"],
+    "partially_relevant_refs": ["e4"],
+    "difficulty": "hard",
+    "tags": ["ordinal", "context-exclusion", "button", "duplicate-labels"],
+    "notes": "Header submit should be excluded before ordinal selection"
+  },
+  {
+    "id": "ordinal-004",
+    "query": "last login link except footer",
+    "relevant_refs": ["e6"],
+    "partially_relevant_refs": ["e5"],
+    "difficulty": "hard",
+    "tags": ["ordinal", "context-exclusion", "link", "duplicate-labels"]
+  },
+  {
+    "id": "ordinal-005",
+    "query": "first name",
+    "relevant_refs": [],
+    "partially_relevant_refs": ["e8", "e9", "e10"],
+    "difficulty": "medium",
+    "tags": ["guard", "literal-text", "textbox"],
+    "notes": "Guard case, should not trigger ordinal parsing just because of the word first"
+  }
+]

--- a/tests/benchmark/corpus/ordinal-context/snapshot.json
+++ b/tests/benchmark/corpus/ordinal-context/snapshot.json
@@ -1,0 +1,13 @@
+[
+  {"ref": "e0", "role": "heading", "name": "Checkout", "interactive": false, "section": "Header"},
+  {"ref": "e1", "role": "button", "name": "Submit", "interactive": true, "section": "Header", "parent": "Header actions", "positional": {"siblingIndex": 0}},
+  {"ref": "e2", "role": "button", "name": "Submit", "interactive": true, "section": "Login", "parent": "Login form", "positional": {"siblingIndex": 1}},
+  {"ref": "e3", "role": "button", "name": "Submit", "interactive": true, "section": "Payment", "parent": "Payment form", "positional": {"siblingIndex": 2}},
+  {"ref": "e4", "role": "button", "name": "Submit", "interactive": true, "section": "Footer", "parent": "Footer actions", "positional": {"siblingIndex": 3}},
+  {"ref": "e5", "role": "link", "name": "Log in", "interactive": true, "section": "Header", "parent": "Header nav", "positional": {"siblingIndex": 4}},
+  {"ref": "e6", "role": "link", "name": "Log in", "interactive": true, "section": "Sidebar", "parent": "Quick actions", "positional": {"siblingIndex": 5}},
+  {"ref": "e7", "role": "link", "name": "Log in", "interactive": true, "section": "Footer", "parent": "Footer nav", "positional": {"siblingIndex": 6}},
+  {"ref": "e8", "role": "textbox", "name": "Email", "interactive": true, "section": "Billing", "parent": "Billing form", "positional": {"siblingIndex": 7}},
+  {"ref": "e9", "role": "textbox", "name": "Email", "interactive": true, "section": "Shipping", "parent": "Shipping form", "positional": {"siblingIndex": 8}},
+  {"ref": "e10", "role": "textbox", "name": "Email", "interactive": true, "section": "Profile", "parent": "Profile form", "positional": {"siblingIndex": 9}}
+]

--- a/tests/e2e/cases/14-find-ordinal.sh
+++ b/tests/e2e/cases/14-find-ordinal.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+CASE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${CASE_DIR}/../lib.sh"
+
+echo "  -- Find: Ordinal Queries --"
+
+MULTI="${ASSETS_DIR}/snapshots/multi-form.json"
+
+result=$(./semantic find "second submit button" --snapshot "$MULTI" --format json)
+assert_json_field "$result" ".best_ref" "e7" "ordinal: second submit button → e7"
+
+result=$(./semantic find "last submit button" --snapshot "$MULTI" --format json)
+assert_json_field "$result" ".best_ref" "e11" "ordinal: last submit button → e11"
+
+result=$(./semantic find "second submit button not in header" --snapshot "$MULTI" --format json)
+assert_json_field "$result" ".best_ref" "e7" "ordinal+context: second submit button not in header → e7"
+
+LOGIN="${ASSETS_DIR}/snapshots/login-page.json"
+result=$(./semantic find "email address" --snapshot "$LOGIN" --format json)
+assert_json_field "$result" ".best_ref" "e1" "guard: literal query still resolves email address → e1"
+
+summary "find-ordinal"

--- a/tests/e2e/cases/14-find-ordinal.sh
+++ b/tests/e2e/cases/14-find-ordinal.sh
@@ -6,17 +6,17 @@ echo "  -- Find: Ordinal Queries --"
 
 MULTI="${ASSETS_DIR}/snapshots/multi-form.json"
 
-result=$(./semantic find "second submit button" --snapshot "$MULTI" --format json)
+result=$(semantic find "second submit button" --snapshot "$MULTI" --format json)
 assert_json_field "$result" ".best_ref" "e7" "ordinal: second submit button → e7"
 
-result=$(./semantic find "last submit button" --snapshot "$MULTI" --format json)
+result=$(semantic find "last submit button" --snapshot "$MULTI" --format json)
 assert_json_field "$result" ".best_ref" "e11" "ordinal: last submit button → e11"
 
-result=$(./semantic find "second submit button not in header" --snapshot "$MULTI" --format json)
-assert_json_field "$result" ".best_ref" "e7" "ordinal+context: second submit button not in header → e7"
+result=$(semantic find "second submit button not in login" --snapshot "$MULTI" --format json)
+assert_json_field "$result" ".best_ref" "e11" "ordinal+context: second submit button not in login → e11"
 
 LOGIN="${ASSETS_DIR}/snapshots/login-page.json"
-result=$(./semantic find "email address" --snapshot "$LOGIN" --format json)
+result=$(semantic find "email address" --snapshot "$LOGIN" --format json)
 assert_json_field "$result" ".best_ref" "e1" "guard: literal query still resolves email address → e1"
 
 summary "find-ordinal"


### PR DESCRIPTION
## Summary
This PR supersedes #30 and delivers the ordinal-query work for #25 in a cleaner follow-up branch.

It adds support for selecting elements by ordinal position among matching candidates, including:
- `first`, `second`, `third`
- numeric ordinals like `3rd`
- `last`
- composition with context exclusion, for example `second submit button not in login`

## What changed
- added ordinal query parsing and selection flow
- preserved document order for ordinal queries, including snapshots without explicit positional hints
- added guard behavior so literal phrases like `first name` are not misparsed as ordinal intent
- composed ordinal selection with context exclusion logic
- added unit coverage for ordinal parsing and matching behavior
- added ordinal corpus benchmark data and e2e coverage
- cleaned up the local dev command from `./dev benchmark` to `./dev bench` while keeping compatibility

## Validation
- `go test ./... -count=1`
- ordinal e2e case passes with the repo-built binary
- `./dev bench`

## Notes
- Supersedes #30
- Closes #25
