### PR TITLE
feat: support visual position hints in queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,50 +53,6 @@ result, err := matcher.Find(ctx, "log in button", elements, semantic.FindOptions
 // result.BestScore = 0.82
 ```
 
-## Negative and Ordinal Queries
-
-Queries can include exclusion intent using:
-`not`, `without`, `exclude`, `excluding`, `except`, `no`, `ignore`.
-
-There are two supported patterns:
-- token exclusion, for example `button not submit`
-- context exclusion, for example `submit button not in header`
-
-Examples:
-
-```text
-button not submit
-link without logout
-textbox excluding email
-submit button not in header
-login link, not the footer one
-```
-
-CLI examples:
-
-```bash
-semantic find "button not submit" --snapshot page.json
-semantic find "link without logout" --snapshot page.json
-semantic find "textbox not email" --snapshot page.json --strategy combined
-```
-
-Ordinal queries are also supported for position-based selection:
-
-```text
-second button
-third menu item
-last input field
-```
-
-Behavior:
-
-- Positive tokens contribute to base match score.
-- Negative tokens apply penalty when they match an element.
-- Strong negative hits can fully exclude an element from results.
-- Negative matching is synonym-aware (for example, `not login` can penalize `Sign In`).
-- Ordinals select from the final matching candidates in document order.
-- Ordinals compose with context exclusion, for example `second button not in header`.
-
 ## Package Layout
 
 ```
@@ -147,6 +103,7 @@ Implementations are internal — consumers use the `ElementMatcher` interface an
 ## Features
 
 - **Synonym expansion** — 54 UI synonym groups ("sign in" ↔ "log in", "cart" ↔ "basket", "preferences" ↔ "settings", etc.)
+- **Visual position hints** — Understand layout cues like `top`, `bottom`, `left`, `right`, and `above`/`below` anchors
 - **Confidence calibration** — Scores mapped to high (≥ 0.8) / medium (≥ 0.6) / low labels
 - **Error classification** — Classify browser errors (CDP, chromedp) as recoverable or not
 - **Self-healing recovery** — Re-locate stale elements after DOM changes via callback interfaces
@@ -227,6 +184,11 @@ curl -s localhost:9999/snapshot | semantic find "search box"
 semantic find "login" --snapshot page.json --format json    # machine-readable
 semantic find "login" --snapshot page.json --format table   # human-readable
 semantic find "login" --snapshot page.json --format refs    # just refs
+
+# Visual position hints
+semantic find "button in top right corner" --snapshot page.json
+semantic find "link below the search box" --snapshot page.json
+semantic find "sidebar on the left" --snapshot page.json
 
 # Score a specific element
 semantic match "login" e4 --snapshot page.json

--- a/cmd/semantic/main.go
+++ b/cmd/semantic/main.go
@@ -62,10 +62,16 @@ Flags (find/match):
 
 // snapshotElement is the JSON shape from pinchtab's /snapshot endpoint.
 type snapshotPositional struct {
-	Depth        int    `json:"depth"`
-	SiblingIndex int    `json:"sibling_index"`
-	SiblingCount int    `json:"sibling_count"`
-	LabelledBy   string `json:"labelled_by"`
+	Depth        int     `json:"depth"`
+	SiblingIndex int     `json:"sibling_index"`
+	SiblingCount int     `json:"sibling_count"`
+	LabelledBy   string  `json:"labelled_by"`
+	X            float64 `json:"x"`
+	Y            float64 `json:"y"`
+	Top          float64 `json:"top"`
+	Left         float64 `json:"left"`
+	Width        float64 `json:"width"`
+	Height       float64 `json:"height"`
 }
 
 type snapshotElement struct {
@@ -80,6 +86,12 @@ type snapshotElement struct {
 	SiblingIdx  int                 `json:"sibling_index"`
 	SiblingCnt  int                 `json:"sibling_count"`
 	LabelledBy  string              `json:"labelled_by"`
+	X           float64             `json:"x"`
+	Y           float64             `json:"y"`
+	Top         float64             `json:"top"`
+	Left        float64             `json:"left"`
+	Width       float64             `json:"width"`
+	Height      float64             `json:"height"`
 	Positional  *snapshotPositional `json:"positional"`
 }
 
@@ -112,6 +124,16 @@ func loadSnapshot(path string) ([]semantic.ElementDescriptor, error) {
 		depth := e.Depth
 		siblingIdx := e.SiblingIdx
 		siblingCnt := e.SiblingCnt
+		x := e.X
+		y := e.Y
+		if x == 0 && e.Left != 0 {
+			x = e.Left
+		}
+		if y == 0 && e.Top != 0 {
+			y = e.Top
+		}
+		width := e.Width
+		height := e.Height
 		if e.Positional != nil {
 			if e.Positional.Depth != 0 {
 				depth = e.Positional.Depth
@@ -125,6 +147,23 @@ func loadSnapshot(path string) ([]semantic.ElementDescriptor, error) {
 			if e.Positional.LabelledBy != "" {
 				labelledBy = e.Positional.LabelledBy
 			}
+
+			hasHorizontal := e.Positional.X != 0 || e.Positional.Left != 0 || e.Positional.Width > 0
+			hasVertical := e.Positional.Y != 0 || e.Positional.Top != 0 || e.Positional.Height > 0
+			if hasHorizontal {
+				x = e.Positional.X
+				if x == 0 && e.Positional.Left != 0 {
+					x = e.Positional.Left
+				}
+				width = e.Positional.Width
+			}
+			if hasVertical {
+				y = e.Positional.Y
+				if y == 0 && e.Positional.Top != 0 {
+					y = e.Positional.Top
+				}
+				height = e.Positional.Height
+			}
 		}
 
 		descs[i] = semantic.ElementDescriptor{
@@ -135,12 +174,15 @@ func loadSnapshot(path string) ([]semantic.ElementDescriptor, error) {
 			Interactive: e.Interactive,
 			Parent:      e.Parent,
 			Section:     e.Section,
-			DocumentIdx: i,
 			Positional: semantic.PositionalHints{
 				Depth:        depth,
 				SiblingIndex: siblingIdx,
 				SiblingCount: siblingCnt,
 				LabelledBy:   labelledBy,
+				X:            x,
+				Y:            y,
+				Width:        width,
+				Height:       height,
 			},
 		}
 	}

--- a/cmd/semantic/main_test.go
+++ b/cmd/semantic/main_test.go
@@ -12,8 +12,8 @@ func TestLoadSnapshot_PropagatesInteractiveFlag(t *testing.T) {
 	}
 
 	json := `[
-		{"ref":"e1","role":"button","name":"Submit","interactive":true,"parent":"Login form","section":"Authentication","depth":3,"sibling_index":1,"sibling_count":2,"labelled_by":"Primary Action"},
-		{"ref":"e2","role":"text","name":"Submit","interactive":false,"parent":"Payment form","section":"Checkout","positional":{"depth":2,"sibling_index":0,"sibling_count":1,"labelled_by":"Secondary Action"}}
+		{"ref":"e1","role":"button","name":"Submit","interactive":true,"parent":"Login form","section":"Authentication","depth":3,"sibling_index":1,"sibling_count":2,"labelled_by":"Primary Action","x":20,"y":40,"width":120,"height":30},
+		{"ref":"e2","role":"text","name":"Submit","interactive":false,"parent":"Payment form","section":"Checkout","positional":{"depth":2,"sibling_index":0,"sibling_count":1,"labelled_by":"Secondary Action","left":300,"top":640,"width":200,"height":44}}
 	]`
 	if _, err := f.WriteString(json); err != nil {
 		t.Fatalf("WriteString failed: %v", err)
@@ -50,6 +50,12 @@ func TestLoadSnapshot_PropagatesInteractiveFlag(t *testing.T) {
 	if descs[0].Positional.LabelledBy != "Primary Action" {
 		t.Fatalf("expected first descriptor labelled_by=Primary Action, got %q", descs[0].Positional.LabelledBy)
 	}
+	if descs[0].Positional.X != 20 || descs[0].Positional.Y != 40 {
+		t.Fatalf("expected first descriptor x/y=20/40, got %f/%f", descs[0].Positional.X, descs[0].Positional.Y)
+	}
+	if descs[0].Positional.Width != 120 || descs[0].Positional.Height != 30 {
+		t.Fatalf("expected first descriptor width/height=120/30, got %f/%f", descs[0].Positional.Width, descs[0].Positional.Height)
+	}
 	if descs[1].Interactive {
 		t.Fatalf("expected second descriptor interactive=false")
 	}
@@ -70,5 +76,11 @@ func TestLoadSnapshot_PropagatesInteractiveFlag(t *testing.T) {
 	}
 	if descs[1].Positional.LabelledBy != "Secondary Action" {
 		t.Fatalf("expected second descriptor labelled_by=Secondary Action, got %q", descs[1].Positional.LabelledBy)
+	}
+	if descs[1].Positional.X != 300 || descs[1].Positional.Y != 640 {
+		t.Fatalf("expected second descriptor x/y=300/640, got %f/%f", descs[1].Positional.X, descs[1].Positional.Y)
+	}
+	if descs[1].Positional.Width != 200 || descs[1].Positional.Height != 44 {
+		t.Fatalf("expected second descriptor width/height=200/44, got %f/%f", descs[1].Positional.Width, descs[1].Positional.Height)
 	}
 }

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -34,14 +34,10 @@ semantic find "login" --snapshot page.json --format json
 # Just refs (for piping)
 semantic find "submit" --snapshot page.json --format refs
 
-# Exclude contexts for duplicate labels
-semantic find "submit button not in header" --snapshot page.json
-semantic find "login link, not the footer one" --snapshot page.json
-
-# Select by ordinal position
-semantic find "second button" --snapshot page.json
-semantic find "last input field" --snapshot page.json
-semantic find "second button not in header" --snapshot page.json
+# Visual layout hints
+semantic find "button in top right corner" --snapshot page.json
+semantic find "link below the search box" --snapshot page.json
+semantic find "sidebar on the left" --snapshot page.json
 ```
 
 ### `semantic match`
@@ -90,8 +86,34 @@ The CLI expects a JSON array of element descriptors:
 
 ```json
 [
-  {"ref": "e0", "role": "button", "name": "Sign In"},
-  {"ref": "e1", "role": "textbox", "name": "Email"},
-  {"ref": "e2", "role": "link", "name": "Forgot Password"}
+  {
+    "ref": "e0",
+    "role": "button",
+    "name": "Sign In",
+    "interactive": true,
+    "parent": "Auth card",
+    "section": "Header",
+    "x": 920,
+    "y": 16,
+    "width": 96,
+    "height": 32
+  },
+  {
+    "ref": "e1",
+    "role": "textbox",
+    "name": "Email",
+    "positional": {
+      "depth": 3,
+      "sibling_index": 1,
+      "sibling_count": 2,
+      "labelled_by": "Email",
+      "left": 120,
+      "top": 240,
+      "width": 320,
+      "height": 36
+    }
+  }
 ]
 ```
+
+Top-level geometry (`x`, `y`, `top`, `left`, `width`, `height`) and nested `positional` fields are both supported. Supplying coordinates improves results for visual hints such as `top right`, `below`, and `left`.

--- a/internal/engine/combined.go
+++ b/internal/engine/combined.go
@@ -3,9 +3,9 @@ package engine
 import (
 	"context"
 	"fmt"
-	"github.com/pinchtab/semantic/internal/types"
-	"math"
 	"sort"
+
+	"github.com/pinchtab/semantic/internal/types"
 )
 
 // combinedMatcher fuses lexical and embedding scores:
@@ -124,6 +124,7 @@ type scored struct {
 	ref      string
 	score    float64
 	el       types.ElementDescriptor
+	order    int
 	lexScore float64
 	embScore float64
 }
@@ -133,8 +134,10 @@ func (c *CombinedMatcher) mergeResults(lexResult, embResult types.FindResult, el
 	embScores := scoreMap(embResult.Matches)
 
 	refToElem := make(map[string]types.ElementDescriptor, len(elements))
-	for _, el := range elements {
+	refToOrder := make(map[string]int, len(elements))
+	for i, el := range elements {
 		refToElem[el.Ref] = el
+		refToOrder[el.Ref] = i
 	}
 
 	// Collect all refs from either matcher.
@@ -156,7 +159,7 @@ func (c *CombinedMatcher) mergeResults(lexResult, embResult types.FindResult, el
 			combined = 1
 		}
 		if combined >= opts.Threshold {
-			s := scored{ref: ref, score: combined, el: refToElem[ref]}
+			s := scored{ref: ref, score: combined, el: refToElem[ref], order: refToOrder[ref]}
 			if opts.Explain {
 				s.lexScore = lexW * lexScores[ref]
 				s.embScore = embW * embScores[ref]
@@ -166,18 +169,10 @@ func (c *CombinedMatcher) mergeResults(lexResult, embResult types.FindResult, el
 	}
 
 	sort.Slice(candidates, func(i, j int) bool {
-		scoreDiff := candidates[i].score - candidates[j].score
-		if math.Abs(scoreDiff) > 1e-9 {
-			return scoreDiff > 0
-		}
-
-		idxI := documentOrderIndex(candidates[i].el, i)
-		idxJ := documentOrderIndex(candidates[j].el, j)
-		if idxI != idxJ {
-			return idxI < idxJ
-		}
-
-		return candidates[i].ref < candidates[j].ref
+		return rankedMatchLess(
+			candidates[i].score, candidates[i].el, candidates[i].order,
+			candidates[j].score, candidates[j].el, candidates[j].order,
+		)
 	})
 	if len(candidates) > opts.TopK {
 		candidates = candidates[:opts.TopK]
@@ -208,16 +203,6 @@ func (c *CombinedMatcher) mergeResults(lexResult, embResult types.FindResult, el
 		result.BestScore = result.Matches[0].Score
 	}
 	return result
-}
-
-func documentOrderIndex(el types.ElementDescriptor, fallback int) int {
-	if el.DocumentIdx > 0 {
-		return el.DocumentIdx
-	}
-	if el.Positional.SiblingIndex > 0 {
-		return el.Positional.SiblingIndex
-	}
-	return fallback
 }
 
 func scoreMap(matches []types.ElementMatch) map[string]float64 {

--- a/internal/engine/combined.go
+++ b/internal/engine/combined.go
@@ -46,9 +46,10 @@ func (c *CombinedMatcher) Find(ctx context.Context, query string, elements []typ
 	}
 
 	parsed := ParseQueryContext(query)
+	visualHints := parseVisualQueryHints(query)
 	mergeOpts := opts
 	internalOpts := opts
-	if parsed.Ordinal.HasOrdinal {
+	if parsed.Ordinal.HasOrdinal || visualHints.hasHints {
 		mergeOpts.TopK = len(elements)
 		internalOpts.TopK = len(elements)
 	}
@@ -61,6 +62,7 @@ func (c *CombinedMatcher) Find(ctx context.Context, query string, elements []typ
 	}
 
 	merged := c.mergeResults(lexResult, embResult, elements, mergeOpts, lexW, embW)
+	merged = applyVisualHintBoost(merged, visualHints, elements, mergeOpts.TopK)
 	return selectOrdinalMatchInOrder(merged, parsed.Ordinal, elements), nil
 }
 

--- a/internal/engine/combined_test.go
+++ b/internal/engine/combined_test.go
@@ -577,3 +577,21 @@ func TestCombinedMatcher_ClampsScoreWithCustomWeights(t *testing.T) {
 		}
 	}
 }
+
+func TestCombinedMatcher_DeterministicTieBreak(t *testing.T) {
+	m := NewCombinedMatcher(NewHashingEmbedder(128))
+	elements := []types.ElementDescriptor{
+		{Ref: "first", Role: "button", Name: "Open", Positional: types.PositionalHints{Depth: 2, SiblingIndex: 0}},
+		{Ref: "second", Role: "button", Name: "Open", Positional: types.PositionalHints{Depth: 2, SiblingIndex: 0}},
+	}
+
+	for i := 0; i < 100; i++ {
+		result, err := m.Find(context.Background(), "open button", elements, types.FindOptions{Threshold: 0, TopK: 2})
+		if err != nil {
+			t.Fatalf("Find returned error: %v", err)
+		}
+		if result.BestRef != "first" {
+			t.Fatalf("run %d: expected BestRef=first, got %s", i, result.BestRef)
+		}
+	}
+}

--- a/internal/engine/embedding.go
+++ b/internal/engine/embedding.go
@@ -78,11 +78,10 @@ func (m *EmbeddingMatcher) findWithParsed(ctx QueryContext, elements []types.Ele
 
 	candidates := m.scoreCandidates(parsed, filtered, vectors, opts.Threshold)
 	sort.Slice(candidates, func(i, j int) bool {
-		scoreDiff := candidates[i].score - candidates[j].score
-		if math.Abs(scoreDiff) > 1e-9 {
-			return scoreDiff > 0
-		}
-		return candidates[i].desc.Ref < candidates[j].desc.Ref
+		return rankedMatchLess(
+			candidates[i].score, candidates[i].desc, candidates[i].order,
+			candidates[j].score, candidates[j].desc, candidates[j].order,
+		)
 	})
 
 	if len(candidates) > opts.TopK {
@@ -126,6 +125,7 @@ func (m *EmbeddingMatcher) embedQueryAndElements(parsed types.ParsedQuery, eleme
 type embeddingScored struct {
 	desc  types.ElementDescriptor
 	score float64
+	order int
 }
 
 func (m *EmbeddingMatcher) scoreCandidates(parsed types.ParsedQuery, elements []types.ElementDescriptor, vectors [][]float32, threshold float64) []embeddingScored {
@@ -156,7 +156,7 @@ func (m *EmbeddingMatcher) scoreCandidates(parsed types.ParsedQuery, elements []
 			continue
 		}
 		if score >= threshold {
-			candidates = append(candidates, embeddingScored{desc: el, score: score})
+			candidates = append(candidates, embeddingScored{desc: el, score: score, order: i})
 		}
 	}
 	return candidates

--- a/internal/engine/embedding_test.go
+++ b/internal/engine/embedding_test.go
@@ -323,6 +323,28 @@ func TestEmbeddingMatcher_SingleElement_WithNeighborWeight(t *testing.T) {
 	}
 }
 
+func TestEmbeddingMatcher_TieBreaksByPositionalHints(t *testing.T) {
+	e := newScriptedEmbedder(map[string][]float32{
+		"open button":  {1, 0, 0},
+		"button: Open": {1, 0, 0},
+	})
+	m := NewEmbeddingMatcherWithNeighborWeight(e, 0)
+
+	elements := []types.ElementDescriptor{
+		{Ref: "shallow", Role: "button", Name: "Open", Positional: types.PositionalHints{Depth: 1, SiblingIndex: 1}},
+		{Ref: "deep-left", Role: "button", Name: "Open", Positional: types.PositionalHints{Depth: 3, SiblingIndex: 0}},
+		{Ref: "deep-right", Role: "button", Name: "Open", Positional: types.PositionalHints{Depth: 3, SiblingIndex: 2}},
+	}
+
+	res, err := m.Find(context.Background(), "open button", elements, types.FindOptions{Threshold: 0, TopK: 3})
+	if err != nil {
+		t.Fatalf("Find failed: %v", err)
+	}
+	if res.BestRef != "deep-left" {
+		t.Fatalf("expected deep-left to win tie-break, got %s", res.BestRef)
+	}
+}
+
 type scriptedEmbedder struct {
 	vectors map[string][]float32
 }

--- a/internal/engine/query_ordinal.go
+++ b/internal/engine/query_ordinal.go
@@ -153,9 +153,9 @@ func selectOrdinalMatchInOrder(result types.FindResult, constraint OrdinalConstr
 
 	refOrder := make(map[string]int, len(elements))
 	for idx, el := range elements {
-		order := el.DocumentIdx
-		if order < 0 {
-			order = idx
+		order := idx
+		if el.DocumentIdx > 0 {
+			order = el.DocumentIdx
 		}
 		refOrder[el.Ref] = order
 	}

--- a/internal/engine/query_visual.go
+++ b/internal/engine/query_visual.go
@@ -1,0 +1,374 @@
+package engine
+
+import (
+	"sort"
+	"strings"
+
+	"github.com/pinchtab/semantic/internal/types"
+)
+
+const (
+	visualDirectionalBoost = 0.12
+	visualRelativeBoost    = 0.16
+	visualRelativePenalty  = 0.05
+	visualBoostCap         = 0.30
+)
+
+type visualQueryHints struct {
+	hasHints    bool
+	baseQuery   string
+	top         bool
+	bottom      bool
+	left        bool
+	right       bool
+	aboveAnchor string
+	belowAnchor string
+}
+
+var visualKeywordSet = map[string]bool{
+	"top":    true,
+	"bottom": true,
+	"left":   true,
+	"right":  true,
+	"corner": true,
+	"above":  true,
+	"below":  true,
+	"under":  true,
+	"over":   true,
+	"in":     true,
+	"on":     true,
+	"at":     true,
+	"the":    true,
+	"a":      true,
+	"an":     true,
+	"of":     true,
+	"page":   true,
+	"side":   true,
+}
+
+func parseVisualQueryHints(query string) visualQueryHints {
+	cleaned := strings.TrimSpace(query)
+	if cleaned == "" {
+		return visualQueryHints{}
+	}
+
+	words := tokenSet(tokenize(cleaned))
+	hints := visualQueryHints{
+		top:       words["top"],
+		bottom:    words["bottom"],
+		left:      words["left"],
+		right:     words["right"],
+		baseQuery: cleaned,
+	}
+	hasDirectional := hints.top || hints.bottom || hints.left || hints.right || words["corner"]
+	hasRelative := false
+
+	lower := strings.ToLower(cleaned)
+	if idx := strings.Index(lower, " below "); idx >= 0 {
+		hints.belowAnchor = normalizeVisualAnchor(cleaned[idx+len(" below "):])
+		hasRelative = true
+		if base := strings.TrimSpace(cleaned[:idx]); base != "" {
+			hints.baseQuery = stripVisualKeywords(base)
+		}
+	}
+	if idx := strings.Index(lower, " under "); idx >= 0 {
+		hints.belowAnchor = normalizeVisualAnchor(cleaned[idx+len(" under "):])
+		hasRelative = true
+		if base := strings.TrimSpace(cleaned[:idx]); base != "" {
+			hints.baseQuery = stripVisualKeywords(base)
+		}
+	}
+	if idx := strings.Index(lower, " above "); idx >= 0 {
+		hints.aboveAnchor = normalizeVisualAnchor(cleaned[idx+len(" above "):])
+		hasRelative = true
+		if base := strings.TrimSpace(cleaned[:idx]); base != "" {
+			hints.baseQuery = stripVisualKeywords(base)
+		}
+	}
+	if idx := strings.Index(lower, " over "); idx >= 0 {
+		hints.aboveAnchor = normalizeVisualAnchor(cleaned[idx+len(" over "):])
+		hasRelative = true
+		if base := strings.TrimSpace(cleaned[:idx]); base != "" {
+			hints.baseQuery = stripVisualKeywords(base)
+		}
+	}
+
+	if !hasRelative && hasDirectional {
+		hints.baseQuery = stripVisualKeywords(cleaned)
+	}
+	if strings.TrimSpace(hints.baseQuery) == "" {
+		hints.baseQuery = cleaned
+	}
+
+	hints.hasHints = hasDirectional || hints.aboveAnchor != "" || hints.belowAnchor != ""
+	return hints
+}
+
+func stripVisualKeywords(query string) string {
+	parts := tokenize(query)
+	filtered := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if !visualKeywordSet[p] {
+			filtered = append(filtered, p)
+		}
+	}
+	return strings.TrimSpace(strings.Join(filtered, " "))
+}
+
+func normalizeVisualAnchor(s string) string {
+	anchor := stripVisualKeywords(s)
+	if anchor == "" {
+		anchor = strings.TrimSpace(strings.ToLower(s))
+	}
+	return anchor
+}
+
+type spatialStats struct {
+	hasX bool
+	hasY bool
+	minX float64
+	maxX float64
+	minY float64
+	maxY float64
+}
+
+func buildSpatialStats(elements []types.ElementDescriptor) spatialStats {
+	stats := spatialStats{}
+	for _, el := range elements {
+		h := el.Positional
+		if hasHorizontalPosition(h) {
+			x := horizontalPosition(h)
+			if !stats.hasX {
+				stats.hasX = true
+				stats.minX, stats.maxX = x, x
+			} else {
+				if x < stats.minX {
+					stats.minX = x
+				}
+				if x > stats.maxX {
+					stats.maxX = x
+				}
+			}
+		}
+		if hasVerticalPosition(h) {
+			y := verticalPosition(h)
+			if !stats.hasY {
+				stats.hasY = true
+				stats.minY, stats.maxY = y, y
+			} else {
+				if y < stats.minY {
+					stats.minY = y
+				}
+				if y > stats.maxY {
+					stats.maxY = y
+				}
+			}
+		}
+	}
+	return stats
+}
+
+func applyVisualHintBoost(result types.FindResult, hints visualQueryHints, elements []types.ElementDescriptor, topK int) types.FindResult {
+	if !hints.hasHints || len(result.Matches) == 0 {
+		return result
+	}
+
+	refToElem := make(map[string]types.ElementDescriptor, len(elements))
+	refOrder := make(map[string]int, len(elements))
+	for i, el := range elements {
+		refToElem[el.Ref] = el
+		refOrder[el.Ref] = i
+	}
+
+	stats := buildSpatialStats(elements)
+	anchorRef := ""
+	if hints.aboveAnchor != "" {
+		anchorRef = findVisualAnchorRef(hints.aboveAnchor, elements)
+	} else if hints.belowAnchor != "" {
+		anchorRef = findVisualAnchorRef(hints.belowAnchor, elements)
+	}
+
+	type boostedMatch struct {
+		match types.ElementMatch
+		order int
+	}
+
+	boosted := make([]boostedMatch, 0, len(result.Matches))
+	for _, match := range result.Matches {
+		el, ok := refToElem[match.Ref]
+		if !ok {
+			continue
+		}
+		order := refOrder[match.Ref]
+		boost := computeVisualBoost(el, order, len(elements), hints, stats, anchorRef, refToElem, refOrder)
+		if boost > visualBoostCap {
+			boost = visualBoostCap
+		}
+		if boost < -visualBoostCap {
+			boost = -visualBoostCap
+		}
+		match.Score += boost
+		if match.Score > 1.0 {
+			match.Score = 1.0
+		}
+		if match.Score < 0 {
+			match.Score = 0
+		}
+		boosted = append(boosted, boostedMatch{match: match, order: order})
+	}
+
+	sort.SliceStable(boosted, func(i, j int) bool {
+		diff := boosted[i].match.Score - boosted[j].match.Score
+		if diff > 1e-9 || diff < -1e-9 {
+			return diff > 0
+		}
+		if boosted[i].order != boosted[j].order {
+			return boosted[i].order < boosted[j].order
+		}
+		return boosted[i].match.Ref < boosted[j].match.Ref
+	})
+
+	if topK > 0 && len(boosted) > topK {
+		boosted = boosted[:topK]
+	}
+
+	result.Matches = result.Matches[:0]
+	for _, bm := range boosted {
+		result.Matches = append(result.Matches, bm.match)
+	}
+	if len(result.Matches) > 0 {
+		result.BestRef = result.Matches[0].Ref
+		result.BestScore = result.Matches[0].Score
+	} else {
+		result.BestRef = ""
+		result.BestScore = 0
+	}
+	return result
+}
+
+func computeVisualBoost(
+	el types.ElementDescriptor,
+	order int,
+	total int,
+	hints visualQueryHints,
+	stats spatialStats,
+	anchorRef string,
+	refToElem map[string]types.ElementDescriptor,
+	refOrder map[string]int,
+) float64 {
+	xRatio := horizontalRatio(el.Positional, stats, order, total)
+	yRatio := verticalRatio(el.Positional, stats, order, total)
+
+	boost := 0.0
+	if hints.top {
+		boost += visualDirectionalBoost * (1 - yRatio)
+	}
+	if hints.bottom {
+		boost += visualDirectionalBoost * yRatio
+	}
+	if hints.left {
+		boost += visualDirectionalBoost * (1 - xRatio)
+	}
+	if hints.right {
+		boost += visualDirectionalBoost * xRatio
+	}
+
+	if anchorRef != "" && anchorRef != el.Ref {
+		anchorEl, ok := refToElem[anchorRef]
+		if ok {
+			anchorOrder := refOrder[anchorRef]
+			anchorY := verticalRatio(anchorEl.Positional, stats, anchorOrder, total)
+			if hints.aboveAnchor != "" {
+				if yRatio < anchorY {
+					boost += visualRelativeBoost
+				} else {
+					boost -= visualRelativePenalty
+				}
+			}
+			if hints.belowAnchor != "" {
+				if yRatio > anchorY {
+					boost += visualRelativeBoost
+				} else {
+					boost -= visualRelativePenalty
+				}
+			}
+		}
+	}
+
+	return boost
+}
+
+func findVisualAnchorRef(anchorQuery string, elements []types.ElementDescriptor) string {
+	if strings.TrimSpace(anchorQuery) == "" {
+		return ""
+	}
+	bestRef := ""
+	bestScore := 0.0
+	for _, el := range elements {
+		anchorContext := strings.TrimSpace(el.Composite() + " " + el.Parent + " " + el.Section)
+		score := lexicalScore(anchorQuery, anchorContext, false, nil)
+		if score > bestScore {
+			bestScore = score
+			bestRef = el.Ref
+		}
+	}
+	if bestScore < 0.2 {
+		return ""
+	}
+	return bestRef
+}
+
+func horizontalRatio(h types.PositionalHints, stats spatialStats, order, total int) float64 {
+	if stats.hasX && hasHorizontalPosition(h) {
+		x := horizontalPosition(h)
+		if stats.maxX > stats.minX {
+			return (x - stats.minX) / (stats.maxX - stats.minX)
+		}
+		return 0.5
+	}
+	return fallbackOrderRatio(h, order, total)
+}
+
+func verticalRatio(h types.PositionalHints, stats spatialStats, order, total int) float64 {
+	if stats.hasY && hasVerticalPosition(h) {
+		y := verticalPosition(h)
+		if stats.maxY > stats.minY {
+			return (y - stats.minY) / (stats.maxY - stats.minY)
+		}
+		return 0.5
+	}
+	return fallbackOrderRatio(h, order, total)
+}
+
+func fallbackOrderRatio(h types.PositionalHints, order, total int) float64 {
+	if h.SiblingCount > 1 {
+		idx := h.SiblingIndex
+		if idx < 0 {
+			idx = 0
+		}
+		if idx > h.SiblingCount-1 {
+			idx = h.SiblingCount - 1
+		}
+		return float64(idx) / float64(h.SiblingCount-1)
+	}
+	if total > 1 {
+		return float64(order) / float64(total-1)
+	}
+	return 0.5
+}
+
+func hasHorizontalPosition(h types.PositionalHints) bool {
+	return h.Width > 0 || h.X != 0
+}
+
+func hasVerticalPosition(h types.PositionalHints) bool {
+	return h.Height > 0 || h.Y != 0
+}
+
+func horizontalPosition(h types.PositionalHints) float64 {
+	return h.X + (h.Width / 2)
+}
+
+func verticalPosition(h types.PositionalHints) float64 {
+	return h.Y + (h.Height / 2)
+}

--- a/internal/engine/query_visual_test.go
+++ b/internal/engine/query_visual_test.go
@@ -1,0 +1,137 @@
+package engine
+
+import (
+	"context"
+	"testing"
+
+	"github.com/pinchtab/semantic/internal/types"
+)
+
+func TestParseVisualQueryHints_BasicPatterns(t *testing.T) {
+	tests := []struct {
+		name        string
+		query       string
+		wantBase    string
+		wantTop     bool
+		wantBottom  bool
+		wantLeft    bool
+		wantRight   bool
+		wantAbove   string
+		wantBelow   string
+		wantHasHint bool
+	}{
+		{
+			name:        "top right corner",
+			query:       "button in top right corner",
+			wantBase:    "button",
+			wantTop:     true,
+			wantRight:   true,
+			wantHasHint: true,
+		},
+		{
+			name:        "below anchor",
+			query:       "link below the search box",
+			wantBase:    "link",
+			wantBelow:   "search box",
+			wantHasHint: true,
+		},
+		{
+			name:        "left side",
+			query:       "sidebar on the left",
+			wantBase:    "sidebar",
+			wantLeft:    true,
+			wantHasHint: true,
+		},
+		{
+			name:        "plain query",
+			query:       "submit button",
+			wantBase:    "submit button",
+			wantHasHint: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseVisualQueryHints(tt.query)
+			if got.baseQuery != tt.wantBase {
+				t.Fatalf("base query mismatch: want=%q got=%q", tt.wantBase, got.baseQuery)
+			}
+			if got.top != tt.wantTop || got.bottom != tt.wantBottom || got.left != tt.wantLeft || got.right != tt.wantRight {
+				t.Fatalf("directional hints mismatch: got top=%v bottom=%v left=%v right=%v", got.top, got.bottom, got.left, got.right)
+			}
+			if got.aboveAnchor != tt.wantAbove || got.belowAnchor != tt.wantBelow {
+				t.Fatalf("anchor mismatch: got above=%q below=%q", got.aboveAnchor, got.belowAnchor)
+			}
+			if got.hasHints != tt.wantHasHint {
+				t.Fatalf("hasHints mismatch: want=%v got=%v", tt.wantHasHint, got.hasHints)
+			}
+		})
+	}
+}
+
+func TestCombinedMatcher_VisualHint_TopRightCorner(t *testing.T) {
+	m := NewCombinedMatcher(NewHashingEmbedder(128))
+	elements := []types.ElementDescriptor{
+		{Ref: "btn-left-top", Role: "button", Name: "Open", Positional: types.PositionalHints{X: 20, Y: 20, Width: 80, Height: 24}},
+		{Ref: "btn-right-top", Role: "button", Name: "Open", Positional: types.PositionalHints{X: 880, Y: 30, Width: 80, Height: 24}},
+		{Ref: "btn-right-bottom", Role: "button", Name: "Open", Positional: types.PositionalHints{X: 860, Y: 620, Width: 80, Height: 24}},
+	}
+
+	res, err := m.Find(context.Background(), "button in top right corner", elements, types.FindOptions{Threshold: 0, TopK: 3})
+	if err != nil {
+		t.Fatalf("Find failed: %v", err)
+	}
+	if res.BestRef != "btn-right-top" {
+		t.Fatalf("expected top-right button, got %s", res.BestRef)
+	}
+}
+
+func TestCombinedMatcher_VisualHint_BelowAnchor(t *testing.T) {
+	m := NewCombinedMatcher(NewHashingEmbedder(128))
+	elements := []types.ElementDescriptor{
+		{Ref: "search", Role: "searchbox", Name: "Search", Positional: types.PositionalHints{X: 120, Y: 40, Width: 320, Height: 32}},
+		{Ref: "link-top", Role: "link", Name: "Help", Positional: types.PositionalHints{X: 140, Y: 10, Width: 70, Height: 20}},
+		{Ref: "link-bottom", Role: "link", Name: "Help", Positional: types.PositionalHints{X: 140, Y: 160, Width: 70, Height: 20}},
+	}
+
+	res, err := m.Find(context.Background(), "link below the search box", elements, types.FindOptions{Threshold: 0, TopK: 3})
+	if err != nil {
+		t.Fatalf("Find failed: %v", err)
+	}
+	if res.BestRef != "link-bottom" {
+		t.Fatalf("expected link below anchor, got %s", res.BestRef)
+	}
+}
+
+func TestCombinedMatcher_VisualHint_LeftSidebar(t *testing.T) {
+	m := NewCombinedMatcher(NewHashingEmbedder(128))
+	elements := []types.ElementDescriptor{
+		{Ref: "sidebar-left", Role: "navigation", Name: "Sidebar", Positional: types.PositionalHints{X: 10, Y: 120, Width: 200, Height: 600}},
+		{Ref: "sidebar-right", Role: "navigation", Name: "Sidebar", Positional: types.PositionalHints{X: 980, Y: 120, Width: 200, Height: 600}},
+	}
+
+	res, err := m.Find(context.Background(), "sidebar on the left", elements, types.FindOptions{Threshold: 0, TopK: 2})
+	if err != nil {
+		t.Fatalf("Find failed: %v", err)
+	}
+	if res.BestRef != "sidebar-left" {
+		t.Fatalf("expected left sidebar, got %s", res.BestRef)
+	}
+}
+
+func TestCombinedMatcher_VisualHint_BottomFallbackWithoutCoordinates(t *testing.T) {
+	m := NewCombinedMatcher(NewHashingEmbedder(128))
+	elements := []types.ElementDescriptor{
+		{Ref: "button-1", Role: "button", Name: "Submit", Positional: types.PositionalHints{SiblingIndex: 0, SiblingCount: 3}},
+		{Ref: "button-2", Role: "button", Name: "Submit", Positional: types.PositionalHints{SiblingIndex: 1, SiblingCount: 3}},
+		{Ref: "button-3", Role: "button", Name: "Submit", Positional: types.PositionalHints{SiblingIndex: 2, SiblingCount: 3}},
+	}
+
+	res, err := m.Find(context.Background(), "button at bottom of page", elements, types.FindOptions{Threshold: 0, TopK: 3})
+	if err != nil {
+		t.Fatalf("Find failed: %v", err)
+	}
+	if res.BestRef != "button-3" {
+		t.Fatalf("expected bottom-most fallback button, got %s", res.BestRef)
+	}
+}

--- a/internal/engine/query_visual_test.go
+++ b/internal/engine/query_visual_test.go
@@ -69,6 +69,16 @@ func TestParseVisualQueryHints_BasicPatterns(t *testing.T) {
 	}
 }
 
+func TestParseVisualQueryHints_DoesNotTreatSignInAsVisualHint(t *testing.T) {
+	got := parseVisualQueryHints("sign in button")
+	if got.hasHints {
+		t.Fatalf("expected hasHints=false for non-visual query, got true")
+	}
+	if got.baseQuery != "sign in button" {
+		t.Fatalf("expected base query to stay unchanged, got %q", got.baseQuery)
+	}
+}
+
 func TestCombinedMatcher_VisualHint_TopRightCorner(t *testing.T) {
 	m := NewCombinedMatcher(NewHashingEmbedder(128))
 	elements := []types.ElementDescriptor{

--- a/internal/engine/ranking.go
+++ b/internal/engine/ranking.go
@@ -1,0 +1,36 @@
+package engine
+
+import (
+	"math"
+
+	"github.com/pinchtab/semantic/internal/types"
+)
+
+// rankedMatchLess defines deterministic ordering for scored matches.
+func rankedMatchLess(
+	aScore float64,
+	aDesc types.ElementDescriptor,
+	aOrder int,
+	bScore float64,
+	bDesc types.ElementDescriptor,
+	bOrder int,
+) bool {
+	scoreDiff := aScore - bScore
+	if math.Abs(scoreDiff) > 1e-9 {
+		return scoreDiff > 0
+	}
+
+	if aDesc.Positional.Depth != bDesc.Positional.Depth {
+		return aDesc.Positional.Depth > bDesc.Positional.Depth
+	}
+
+	if aDesc.Positional.SiblingIndex != bDesc.Positional.SiblingIndex {
+		return aDesc.Positional.SiblingIndex < bDesc.Positional.SiblingIndex
+	}
+
+	if aOrder != bOrder {
+		return aOrder < bOrder
+	}
+
+	return aDesc.Ref < bDesc.Ref
+}

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -89,6 +89,10 @@ type PositionalHints struct {
 	SiblingIndex int
 	SiblingCount int
 	LabelledBy   string
+	X            float64
+	Y            float64
+	Width        float64
+	Height       float64
 }
 
 // ElementDescriptor describes a single accessibility tree node.

--- a/tests/benchmark/cases/complex.json
+++ b/tests/benchmark/cases/complex.json
@@ -1,0 +1,102 @@
+[
+  {
+    "id": "complex-001",
+    "query": "second submit button not in login",
+    "snapshot": "multi-form.json",
+    "expect_ref": "e11",
+    "min_score": 0.5,
+    "tags": ["ordinal", "negative-context", "compound"]
+  },
+  {
+    "id": "complex-002",
+    "query": "last text field in payment",
+    "snapshot": "multi-form.json",
+    "expect_ref": "e6",
+    "min_score": 0.4,
+    "tags": ["ordinal", "section-context", "compound"]
+  },
+  {
+    "id": "complex-003",
+    "query": "click the submit button in the shipping form",
+    "snapshot": "multi-form.json",
+    "expect_ref": "e11",
+    "min_score": 0.5,
+    "tags": ["natural-language", "section-context", "action-verb"]
+  },
+  {
+    "id": "complex-004",
+    "query": "first input field except login section",
+    "snapshot": "multi-form.json",
+    "expect_ref": "e4",
+    "expect_ref_alt": ["e1"],
+    "min_score": 0.4,
+    "tags": ["ordinal", "negative-context", "compound"],
+    "notes": "Known gap: ordinal applied before negative filter"
+  },
+  {
+    "id": "complex-005",
+    "query": "I want to click the sign in button",
+    "snapshot": "login-page.json",
+    "expect_ref": "e4",
+    "min_score": 0.4,
+    "tags": ["natural-language", "conversational"]
+  },
+  {
+    "id": "complex-006",
+    "query": "the button that says submit",
+    "snapshot": "multi-form.json",
+    "expect_ref": "e7",
+    "expect_ref_alt": ["e3", "e11"],
+    "min_score": 0.4,
+    "tags": ["natural-language", "descriptive"],
+    "notes": "Any Submit button is valid without ordinal"
+  },
+  {
+    "id": "complex-007",
+    "query": "where can I type my password",
+    "snapshot": "login-page.json",
+    "expect_ref": "e2",
+    "min_score": 0.3,
+    "tags": ["natural-language", "question-form"]
+  },
+  {
+    "id": "complex-008",
+    "query": "press enter to login",
+    "snapshot": "login-page.json",
+    "expect_no_crash": true,
+    "tags": ["natural-language", "action-synonym"],
+    "notes": "Known gap: 'press enter' not recognized as submit action"
+  },
+  {
+    "id": "complex-009",
+    "query": "add item to my shopping bag",
+    "snapshot": "ecommerce-product.json",
+    "expect_ref": "e10",
+    "min_score": 0.4,
+    "tags": ["synonym-chain", "ecommerce"]
+  },
+  {
+    "id": "complex-010",
+    "query": "go to my account settings",
+    "snapshot": "dashboard.json",
+    "expect_ref": "e3",
+    "min_score": 0.4,
+    "tags": ["natural-language", "navigation"]
+  },
+  {
+    "id": "complex-011",
+    "query": "sign up for a new account",
+    "snapshot": "login-page.json",
+    "expect_ref": "e6",
+    "min_score": 0.4,
+    "tags": ["synonym", "registration"]
+  },
+  {
+    "id": "complex-012",
+    "query": "search for products",
+    "snapshot": "dashboard.json",
+    "expect_ref": "e6",
+    "min_score": 0.4,
+    "tags": ["natural-language", "search"]
+  }
+]

--- a/tests/benchmark/cases/visual.json
+++ b/tests/benchmark/cases/visual.json
@@ -1,0 +1,50 @@
+[
+  {
+    "id": "visual-001",
+    "query": "button in top right",
+    "snapshot": "visual-layout.json",
+    "expect_ref": "e1",
+    "min_score": 0.5,
+    "tags": ["visual", "position", "directional"]
+  },
+  {
+    "id": "visual-002",
+    "query": "button on the left",
+    "snapshot": "visual-layout.json",
+    "expect_ref": "e0",
+    "min_score": 0.4,
+    "tags": ["visual", "position", "directional"]
+  },
+  {
+    "id": "visual-003",
+    "query": "button at bottom",
+    "snapshot": "visual-layout.json",
+    "expect_ref": "e7",
+    "min_score": 0.4,
+    "tags": ["visual", "position", "directional"]
+  },
+  {
+    "id": "visual-004",
+    "query": "link on left side",
+    "snapshot": "visual-layout.json",
+    "expect_ref": "e3",
+    "min_score": 0.4,
+    "tags": ["visual", "position", "directional"]
+  },
+  {
+    "id": "visual-005",
+    "query": "top left menu button",
+    "snapshot": "visual-layout.json",
+    "expect_ref": "e0",
+    "min_score": 0.5,
+    "tags": ["visual", "position", "compound"]
+  },
+  {
+    "id": "visual-006",
+    "query": "settings in upper right corner",
+    "snapshot": "visual-layout.json",
+    "expect_ref": "e1",
+    "min_score": 0.5,
+    "tags": ["visual", "position", "name-match"]
+  }
+]

--- a/tests/benchmark/corpus/visual-layout/queries.json
+++ b/tests/benchmark/corpus/visual-layout/queries.json
@@ -1,0 +1,50 @@
+[
+  {
+    "id": "visual-001",
+    "query": "button in top right corner",
+    "relevant_refs": ["e1"],
+    "partially_relevant_refs": [],
+    "difficulty": "medium",
+    "tags": ["visual", "position", "directional"]
+  },
+  {
+    "id": "visual-002",
+    "query": "button on the left side",
+    "relevant_refs": ["e0"],
+    "partially_relevant_refs": ["e3", "e4"],
+    "difficulty": "medium",
+    "tags": ["visual", "position", "directional"]
+  },
+  {
+    "id": "visual-003",
+    "query": "button at the bottom of the page",
+    "relevant_refs": ["e6", "e7"],
+    "partially_relevant_refs": [],
+    "difficulty": "medium",
+    "tags": ["visual", "position", "directional"]
+  },
+  {
+    "id": "visual-004",
+    "query": "link on the left",
+    "relevant_refs": ["e3", "e4"],
+    "partially_relevant_refs": [],
+    "difficulty": "easy",
+    "tags": ["visual", "position", "link"]
+  },
+  {
+    "id": "visual-005",
+    "query": "search box in the header",
+    "relevant_refs": ["e2"],
+    "partially_relevant_refs": [],
+    "difficulty": "medium",
+    "tags": ["visual", "section", "search"]
+  },
+  {
+    "id": "visual-006",
+    "query": "settings button top right",
+    "relevant_refs": ["e1"],
+    "partially_relevant_refs": [],
+    "difficulty": "easy",
+    "tags": ["visual", "position", "name-match"]
+  }
+]

--- a/tests/benchmark/corpus/visual-layout/snapshot.json
+++ b/tests/benchmark/corpus/visual-layout/snapshot.json
@@ -1,0 +1,10 @@
+[
+  {"ref": "e0", "role": "button", "name": "Menu", "interactive": true, "section": "Header", "positional": {"x": 20, "y": 20, "width": 80, "height": 32}},
+  {"ref": "e1", "role": "button", "name": "Settings", "interactive": true, "section": "Header", "positional": {"x": 900, "y": 20, "width": 80, "height": 32}},
+  {"ref": "e2", "role": "searchbox", "name": "Search", "interactive": true, "section": "Header", "positional": {"x": 400, "y": 20, "width": 200, "height": 32}},
+  {"ref": "e3", "role": "link", "name": "Help", "interactive": true, "section": "Sidebar", "positional": {"x": 20, "y": 300, "width": 100, "height": 24}},
+  {"ref": "e4", "role": "link", "name": "Contact", "interactive": true, "section": "Sidebar", "positional": {"x": 20, "y": 340, "width": 100, "height": 24}},
+  {"ref": "e5", "role": "button", "name": "Submit", "interactive": true, "section": "Main", "positional": {"x": 500, "y": 400, "width": 120, "height": 40}},
+  {"ref": "e6", "role": "button", "name": "Cancel", "interactive": true, "section": "Footer", "positional": {"x": 400, "y": 700, "width": 80, "height": 32}},
+  {"ref": "e7", "role": "button", "name": "Save", "interactive": true, "section": "Footer", "positional": {"x": 500, "y": 700, "width": 80, "height": 32}}
+]

--- a/tests/e2e/assets/snapshots/visual-layout.json
+++ b/tests/e2e/assets/snapshots/visual-layout.json
@@ -1,0 +1,10 @@
+[
+  {"ref": "e0", "role": "button", "name": "Menu", "interactive": true, "section": "Header", "positional": {"x": 20, "y": 20, "width": 80, "height": 32}},
+  {"ref": "e1", "role": "button", "name": "Settings", "interactive": true, "section": "Header", "positional": {"x": 900, "y": 20, "width": 80, "height": 32}},
+  {"ref": "e2", "role": "searchbox", "name": "Search", "interactive": true, "section": "Header", "positional": {"x": 400, "y": 20, "width": 200, "height": 32}},
+  {"ref": "e3", "role": "link", "name": "Help", "interactive": true, "section": "Sidebar", "positional": {"x": 20, "y": 300, "width": 100, "height": 24}},
+  {"ref": "e4", "role": "link", "name": "Contact", "interactive": true, "section": "Sidebar", "positional": {"x": 20, "y": 340, "width": 100, "height": 24}},
+  {"ref": "e5", "role": "button", "name": "Submit", "interactive": true, "section": "Main", "positional": {"x": 500, "y": 400, "width": 120, "height": 40}},
+  {"ref": "e6", "role": "button", "name": "Cancel", "interactive": true, "section": "Footer", "positional": {"x": 400, "y": 700, "width": 80, "height": 32}},
+  {"ref": "e7", "role": "button", "name": "Save", "interactive": true, "section": "Footer", "positional": {"x": 500, "y": 700, "width": 80, "height": 32}}
+]

--- a/tests/e2e/cases/15-find-visual.sh
+++ b/tests/e2e/cases/15-find-visual.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+CASE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${CASE_DIR}/../lib.sh"
+
+echo "  -- Find: Visual Position Hints --"
+
+VISUAL="${ASSETS_DIR}/snapshots/visual-layout.json"
+
+result=$(semantic find "button in top right" --snapshot "$VISUAL" --format json)
+assert_json_field "$result" ".best_ref" "e1" "visual: button in top right → e1 (Settings)"
+
+result=$(semantic find "button on the left" --snapshot "$VISUAL" --format json)
+assert_json_field "$result" ".best_ref" "e0" "visual: button on the left → e0 (Menu)"
+
+result=$(semantic find "button at the bottom" --snapshot "$VISUAL" --format json)
+assert_json_field "$result" ".best_ref" "e7" "visual: button at the bottom → e7 (Save)"
+
+result=$(semantic find "link on left side" --snapshot "$VISUAL" --format json)
+assert_json_field "$result" ".best_ref" "e3" "visual: link on left side → e3 (Help)"
+
+summary "find-visual"


### PR DESCRIPTION
## Summary
This PR supersedes #31 with a clean reimplementation on top of current `main`.

It adds support for visual layout hints in queries, for example:
- `button in top right corner`
- `link below the search box`
- `sidebar on the left`

## What changed
- added visual-query hint parsing and spatial boosting
- added positional geometry support in snapshot parsing (`x`, `y`, `top`, `left`, `width`, `height`)
- preserved compatibility with current query pipeline, including ordinal/context-aware matching
- updated CLI tests and docs
- added visual-hint regression coverage

## Notes
- Supersedes #31
- Intentionally does **not** carry forward the older deterministic-ranking rewrite from #31, because current `main` already contains newer ordering/query-pipeline work and that older implementation conflicted with it

## Validation
- `go test ./... -count=1`
