### PR TITLE
feat: harden matchers with input sanitization and context cancellation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
-# Binary (root only, not cmd/semantic/)
+# Binary
 /semantic
+tests/benchmark/semantic
+tests/e2e/semantic
 *.exe
 
 # Test

--- a/internal/engine/combined.go
+++ b/internal/engine/combined.go
@@ -3,6 +3,7 @@ package engine
 import (
 	"context"
 	"fmt"
+	"math"
 	"sort"
 
 	"github.com/pinchtab/semantic/internal/types"
@@ -41,9 +42,11 @@ func (c *CombinedMatcher) Strategy() string {
 }
 
 func (c *CombinedMatcher) Find(ctx context.Context, query string, elements []types.ElementDescriptor, opts types.FindOptions) (types.FindResult, error) {
-	if opts.TopK <= 0 {
-		opts.TopK = 3
+	if ctx == nil {
+		ctx = context.Background()
 	}
+
+	opts = sanitizeFindOptions(opts, len(elements), 3)
 
 	parsed := ParseQueryContext(query)
 	visualHints := parseVisualQueryHints(query)
@@ -67,10 +70,49 @@ func (c *CombinedMatcher) Find(ctx context.Context, query string, elements []typ
 }
 
 func (c *CombinedMatcher) weights(opts types.FindOptions) (float64, float64) {
-	if opts.LexicalWeight > 0 || opts.EmbeddingWeight > 0 {
-		return opts.LexicalWeight, opts.EmbeddingWeight
+	baseLex, baseEmb := normalizeWeights(c.LexicalWeight, c.EmbeddingWeight)
+	if baseLex == 0 && baseEmb == 0 {
+		baseLex, baseEmb = 0.6, 0.4
 	}
-	return c.LexicalWeight, c.EmbeddingWeight
+
+	reqLex := sanitizeWeight(opts.LexicalWeight)
+	reqEmb := sanitizeWeight(opts.EmbeddingWeight)
+	if reqLex == 0 && reqEmb == 0 {
+		return baseLex, baseEmb
+	}
+
+	if reqLex > 0 && reqEmb == 0 && reqLex <= 1 {
+		reqEmb = 1 - reqLex
+	}
+	if reqEmb > 0 && reqLex == 0 && reqEmb <= 1 {
+		reqLex = 1 - reqEmb
+	}
+
+	lex, emb := normalizeWeights(reqLex, reqEmb)
+	if lex == 0 && emb == 0 {
+		return baseLex, baseEmb
+	}
+
+	return lex, emb
+}
+
+func sanitizeWeight(weight float64) float64 {
+	if math.IsNaN(weight) || math.IsInf(weight, 0) || weight < 0 {
+		return 0
+	}
+	return weight
+}
+
+func normalizeWeights(lexicalWeight, embeddingWeight float64) (float64, float64) {
+	lexicalWeight = sanitizeWeight(lexicalWeight)
+	embeddingWeight = sanitizeWeight(embeddingWeight)
+
+	total := lexicalWeight + embeddingWeight
+	if total <= 0 {
+		return 0, 0
+	}
+
+	return lexicalWeight / total, embeddingWeight / total
 }
 
 type matcherResult struct {
@@ -108,8 +150,19 @@ func (c *CombinedMatcher) runBothParsed(ctx context.Context, parsed QueryContext
 		embCh <- matcherResult{r, err}
 	}()
 
-	lexRes := <-lexCh
-	embRes := <-embCh
+	var lexRes, embRes matcherResult
+	gotLex, gotEmb := false, false
+
+	for !gotLex || !gotEmb {
+		select {
+		case <-ctx.Done():
+			return types.FindResult{}, types.FindResult{}, ctx.Err()
+		case lexRes = <-lexCh:
+			gotLex = true
+		case embRes = <-embCh:
+			gotEmb = true
+		}
+	}
 
 	if lexRes.err != nil {
 		return types.FindResult{}, types.FindResult{}, lexRes.err

--- a/internal/engine/combined_test.go
+++ b/internal/engine/combined_test.go
@@ -2,9 +2,13 @@ package engine
 
 import (
 	"context"
+	"errors"
 	"fmt"
-	"github.com/pinchtab/semantic/internal/types"
+	"math"
 	"testing"
+	"time"
+
+	"github.com/pinchtab/semantic/internal/types"
 )
 
 // CATEGORY 6: Role Boost Accumulation Test (Bug Fix)
@@ -593,5 +597,148 @@ func TestCombinedMatcher_DeterministicTieBreak(t *testing.T) {
 		if result.BestRef != "first" {
 			t.Fatalf("run %d: expected BestRef=first, got %s", i, result.BestRef)
 		}
+	}
+}
+
+// Hardening tests
+
+func TestCombinedMatcher_Weights_AdversarialNormalizationGrid(t *testing.T) {
+	m := NewCombinedMatcher(NewHashingEmbedder(128))
+
+	inputs := []float64{
+		-10, -1, -0.25, 0, 0.001, 0.2, 0.5, 0.9, 1, 2, 10,
+		math.NaN(), math.Inf(1),
+	}
+
+	for _, baseLex := range inputs {
+		for _, baseEmb := range inputs {
+			m.LexicalWeight = baseLex
+			m.EmbeddingWeight = baseEmb
+
+			for _, reqLex := range inputs {
+				for _, reqEmb := range inputs {
+					lex, emb := m.weights(types.FindOptions{LexicalWeight: reqLex, EmbeddingWeight: reqEmb})
+
+					if math.IsNaN(lex) || math.IsNaN(emb) || math.IsInf(lex, 0) || math.IsInf(emb, 0) {
+						t.Fatalf("non-finite weights from base=(%v,%v) req=(%v,%v): lexical=%v embedding=%v",
+							baseLex, baseEmb, reqLex, reqEmb, lex, emb)
+					}
+					if lex < 0 || emb < 0 {
+						t.Fatalf("negative weights from base=(%v,%v) req=(%v,%v): lexical=%v embedding=%v",
+							baseLex, baseEmb, reqLex, reqEmb, lex, emb)
+					}
+
+					sum := lex + emb
+					if math.Abs(sum-1) > 1e-9 {
+						t.Fatalf("weights do not normalize to 1 from base=(%v,%v) req=(%v,%v): sum=%v",
+							baseLex, baseEmb, reqLex, reqEmb, sum)
+					}
+				}
+			}
+		}
+	}
+}
+
+func TestCombinedMatcher_ScoreBoundedUnderInvalidModelWeights(t *testing.T) {
+	m := NewCombinedMatcher(NewHashingEmbedder(128))
+	m.LexicalWeight = 9
+	m.EmbeddingWeight = 9
+
+	elements := []types.ElementDescriptor{
+		{Ref: "e0", Role: "button", Name: "Sign in"},
+		{Ref: "e1", Role: "link", Name: "Register"},
+	}
+
+	result, err := m.Find(context.Background(), "sign in button", elements, types.FindOptions{Threshold: 0, TopK: 2})
+	if err != nil {
+		t.Fatalf("Find returned error: %v", err)
+	}
+	if result.BestScore < 0 || result.BestScore > 1 {
+		t.Fatalf("best score out of [0,1]: %f", result.BestScore)
+	}
+	for _, match := range result.Matches {
+		if match.Score < 0 || match.Score > 1 {
+			t.Fatalf("match %s score out of [0,1]: %f", match.Ref, match.Score)
+		}
+	}
+}
+
+func TestCombinedMatcher_Find_ContextCanceledWhileEmbeddingBlocked(t *testing.T) {
+	e := &blockingEmbedder{started: make(chan struct{}), release: make(chan struct{})}
+	defer close(e.release)
+
+	m := NewCombinedMatcher(e)
+	elements := []types.ElementDescriptor{
+		{Ref: "e1", Role: "button", Name: "Save"},
+		{Ref: "e2", Role: "link", Name: "Cancel"},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		_, err := m.Find(ctx, "save button", elements, types.FindOptions{Threshold: 0, TopK: 2})
+		done <- err
+	}()
+
+	select {
+	case <-e.started:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("expected embedding to start")
+	}
+
+	cancel()
+
+	select {
+	case err := <-done:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("expected context canceled error, got %v", err)
+		}
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("Find did not return promptly after context cancellation")
+	}
+}
+
+type blockingEmbedder struct {
+	started chan struct{}
+	release chan struct{}
+}
+
+func (e *blockingEmbedder) Strategy() string { return "blocking" }
+
+func (e *blockingEmbedder) Embed(texts []string) ([][]float32, error) {
+	close(e.started)
+	<-e.release
+	return nil, errors.New("released")
+}
+
+func TestSanitizeFindOptions(t *testing.T) {
+	tests := []struct {
+		name        string
+		opts        types.FindOptions
+		elemCount   int
+		defaultTopK int
+		wantTopK    int
+		wantThresh  float64
+	}{
+		{"zero topk uses default", types.FindOptions{TopK: 0}, 10, 3, 3, 0},
+		{"negative topk uses default", types.FindOptions{TopK: -5}, 10, 3, 3, 0},
+		{"topk exceeds elements clamped", types.FindOptions{TopK: 20}, 5, 3, 5, 0},
+		{"NaN threshold becomes 0", types.FindOptions{Threshold: math.NaN()}, 10, 3, 3, 0},
+		{"Inf threshold becomes 0", types.FindOptions{Threshold: math.Inf(1)}, 10, 3, 3, 0},
+		{"negative threshold becomes 0", types.FindOptions{Threshold: -0.5}, 10, 3, 3, 0},
+		{"threshold > 1 becomes 1", types.FindOptions{Threshold: 1.5}, 10, 3, 3, 1},
+		{"valid threshold preserved", types.FindOptions{Threshold: 0.5, TopK: 5}, 10, 3, 5, 0.5},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := sanitizeFindOptions(tt.opts, tt.elemCount, tt.defaultTopK)
+			if got.TopK != tt.wantTopK {
+				t.Errorf("TopK = %d, want %d", got.TopK, tt.wantTopK)
+			}
+			if got.Threshold != tt.wantThresh {
+				t.Errorf("Threshold = %f, want %f", got.Threshold, tt.wantThresh)
+			}
+		})
 	}
 }

--- a/internal/engine/embedding.go
+++ b/internal/engine/embedding.go
@@ -2,10 +2,12 @@ package engine
 
 import (
 	"context"
-	"github.com/pinchtab/semantic/internal/types"
+	"fmt"
 	"math"
 	"sort"
 	"strings"
+
+	"github.com/pinchtab/semantic/internal/types"
 )
 
 // Embedder converts text into dense vectors. See NewHashingEmbedder.
@@ -48,16 +50,27 @@ func (m *EmbeddingMatcher) Strategy() string {
 	return "embedding:" + m.embedder.Strategy()
 }
 
-func (m *EmbeddingMatcher) Find(_ context.Context, query string, elements []types.ElementDescriptor, opts types.FindOptions) (types.FindResult, error) {
-	ctx := ParseQueryContext(query)
-	return m.findWithParsed(ctx, elements, opts)
+// contextAwareEmbedder is an optional interface for embedders that support
+// context cancellation during embedding.
+type contextAwareEmbedder interface {
+	EmbedContext(ctx context.Context, texts []string) ([][]float32, error)
 }
 
-func (m *EmbeddingMatcher) findWithParsed(ctx QueryContext, elements []types.ElementDescriptor, opts types.FindOptions) (types.FindResult, error) {
-	parsed := ctx.Base
-	if opts.TopK <= 0 {
-		opts.TopK = 3
+func (m *EmbeddingMatcher) Find(ctx context.Context, query string, elements []types.ElementDescriptor, opts types.FindOptions) (types.FindResult, error) {
+	if ctx == nil {
+		ctx = context.Background()
 	}
+	if err := ctx.Err(); err != nil {
+		return types.FindResult{}, err
+	}
+
+	queryCtx := ParseQueryContext(query)
+	return m.findWithParsedContext(ctx, queryCtx, elements, opts)
+}
+
+func (m *EmbeddingMatcher) findWithParsedContext(ctx context.Context, queryCtx QueryContext, elements []types.ElementDescriptor, opts types.FindOptions) (types.FindResult, error) {
+	parsed := queryCtx.Base
+	opts = sanitizeFindOptions(opts, len(elements), 3)
 
 	if len(parsed.Positive) == 0 && len(parsed.Negative) == 0 {
 		return types.FindResult{
@@ -66,17 +79,25 @@ func (m *EmbeddingMatcher) findWithParsed(ctx QueryContext, elements []types.Ele
 		}, nil
 	}
 
-	filtered := filterContextExcludedElements(elements, ctx)
+	filtered := filterContextExcludedElements(elements, queryCtx)
 	if len(filtered) == 0 {
 		return types.FindResult{Strategy: m.Strategy(), ElementCount: len(elements)}, nil
 	}
 
-	vectors, err := m.embedQueryAndElements(parsed, filtered)
+	vectors, err := m.embedQueryAndElementsWithContext(ctx, parsed, filtered)
 	if err != nil {
 		return types.FindResult{}, err
 	}
 
-	candidates := m.scoreCandidates(parsed, filtered, vectors, opts.Threshold)
+	if err := validateEmbeddedVectors(vectors, len(filtered)+countQueryVectors(parsed)); err != nil {
+		return types.FindResult{}, err
+	}
+
+	if err := ctx.Err(); err != nil {
+		return types.FindResult{}, err
+	}
+
+	candidates := m.scoreCandidatesWithContext(ctx, parsed, filtered, vectors, opts.Threshold)
 	sort.Slice(candidates, func(i, j int) bool {
 		return rankedMatchLess(
 			candidates[i].score, candidates[i].desc, candidates[i].order,
@@ -91,6 +112,10 @@ func (m *EmbeddingMatcher) findWithParsed(ctx QueryContext, elements []types.Ele
 	return buildEmbeddingResult(m.Strategy(), len(elements), candidates), nil
 }
 
+func (m *EmbeddingMatcher) findWithParsed(queryCtx QueryContext, elements []types.ElementDescriptor, opts types.FindOptions) (types.FindResult, error) {
+	return m.findWithParsedContext(context.Background(), queryCtx, elements, opts)
+}
+
 func filterContextExcludedElements(elements []types.ElementDescriptor, ctx QueryContext) []types.ElementDescriptor {
 	filtered := make([]types.ElementDescriptor, 0, len(elements))
 	for _, el := range elements {
@@ -102,7 +127,7 @@ func filterContextExcludedElements(elements []types.ElementDescriptor, ctx Query
 	return filtered
 }
 
-func (m *EmbeddingMatcher) embedQueryAndElements(parsed types.ParsedQuery, elements []types.ElementDescriptor) ([][]float32, error) {
+func (m *EmbeddingMatcher) embedQueryAndElementsWithContext(ctx context.Context, parsed types.ParsedQuery, elements []types.ElementDescriptor) ([][]float32, error) {
 	positiveQuery := strings.Join(parsed.Positive, " ")
 	negativeQuery := strings.Join(parsed.Negative, " ")
 
@@ -119,7 +144,44 @@ func (m *EmbeddingMatcher) embedQueryAndElements(parsed types.ParsedQuery, eleme
 		texts = append(texts, negativeQuery)
 	}
 	texts = append(texts, descs...)
-	return m.embedder.Embed(texts)
+	return embedWithContext(ctx, m.embedder, texts)
+}
+
+func embedWithContext(ctx context.Context, embedder Embedder, texts []string) ([][]float32, error) {
+	if ce, ok := embedder.(contextAwareEmbedder); ok {
+		return ce.EmbedContext(ctx, texts)
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	return embedder.Embed(texts)
+}
+
+func countQueryVectors(parsed types.ParsedQuery) int {
+	count := 0
+	if len(parsed.Positive) > 0 {
+		count++
+	}
+	if len(parsed.Negative) > 0 {
+		count++
+	}
+	return count
+}
+
+func validateEmbeddedVectors(vectors [][]float32, expected int) error {
+	if len(vectors) != expected {
+		return fmt.Errorf("embedder returned %d vectors, expected %d", len(vectors), expected)
+	}
+	if len(vectors) == 0 {
+		return nil
+	}
+	dim := len(vectors[0])
+	for i := 1; i < len(vectors); i++ {
+		if len(vectors[i]) != dim {
+			return fmt.Errorf("embedder returned inconsistent vector dimensions at index %d: %d vs %d", i, len(vectors[i]), dim)
+		}
+	}
+	return nil
 }
 
 type embeddingScored struct {
@@ -128,7 +190,7 @@ type embeddingScored struct {
 	order int
 }
 
-func (m *EmbeddingMatcher) scoreCandidates(parsed types.ParsedQuery, elements []types.ElementDescriptor, vectors [][]float32, threshold float64) []embeddingScored {
+func (m *EmbeddingMatcher) scoreCandidatesWithContext(ctx context.Context, parsed types.ParsedQuery, elements []types.ElementDescriptor, vectors [][]float32, threshold float64) []embeddingScored {
 	negativeOnly := len(parsed.Positive) == 0 && len(parsed.Negative) > 0
 	idx := 0
 	var posVec []float32
@@ -151,6 +213,11 @@ func (m *EmbeddingMatcher) scoreCandidates(parsed types.ParsedQuery, elements []
 
 	var candidates []embeddingScored
 	for i, el := range elements {
+		if i%64 == 0 {
+			if ctx.Err() != nil {
+				return candidates
+			}
+		}
 		score := scoreEmbeddingCandidate(parsed, posVec, negVec, contextVecs[i], elemVecs[i])
 		if negativeOnly && score == 0 {
 			continue

--- a/internal/engine/embedding_test.go
+++ b/internal/engine/embedding_test.go
@@ -2,10 +2,12 @@ package engine
 
 import (
 	"context"
+	"errors"
 	"fmt"
-	"github.com/pinchtab/semantic/internal/types"
 	"math"
 	"testing"
+
+	"github.com/pinchtab/semantic/internal/types"
 )
 
 // dummyEmbedder tests
@@ -382,3 +384,108 @@ func findMatchScore(matches []types.ElementMatch, ref string) (float64, bool) {
 }
 
 // FindResult.ConfidenceLabel tests
+
+// Hardening tests
+
+func TestEmbeddingMatcher_Find_ContextCanceledBeforeEmbed(t *testing.T) {
+	m := NewEmbeddingMatcher(newDummyEmbedder(64))
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := m.Find(ctx, "submit button", []types.ElementDescriptor{
+		{Ref: "e1", Role: "button", Name: "Submit"},
+	}, types.FindOptions{Threshold: 0, TopK: 1})
+
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context canceled error, got %v", err)
+	}
+}
+
+func TestEmbeddingMatcher_Find_EmbedderVectorCountMismatchReturnsError(t *testing.T) {
+	e := &malformedEmbedder{vectors: fixedVectors(1, 64)}
+	m := NewEmbeddingMatcher(e)
+
+	_, err := m.Find(context.Background(), "submit", []types.ElementDescriptor{
+		{Ref: "e1", Role: "button", Name: "Submit"},
+		{Ref: "e2", Role: "button", Name: "Cancel"},
+	}, types.FindOptions{Threshold: 0, TopK: 2})
+
+	if err == nil {
+		t.Fatal("expected error for vector count mismatch")
+	}
+}
+
+func TestEmbeddingMatcher_Find_InconsistentVectorDimensionsReturnsError(t *testing.T) {
+	e := &malformedEmbedder{vectors: [][]float32{
+		{1, 0, 0},
+		{0, 1},
+		{0, 0, 1},
+	}}
+	m := NewEmbeddingMatcher(e)
+
+	_, err := m.Find(context.Background(), "submit", []types.ElementDescriptor{
+		{Ref: "e1", Role: "button", Name: "Submit"},
+		{Ref: "e2", Role: "button", Name: "Cancel"},
+	}, types.FindOptions{Threshold: 0, TopK: 2})
+
+	if err == nil {
+		t.Fatal("expected error for inconsistent vector dimensions")
+	}
+}
+
+type malformedEmbedder struct {
+	vectors [][]float32
+}
+
+func (e *malformedEmbedder) Strategy() string { return "malformed" }
+
+func (e *malformedEmbedder) Embed(texts []string) ([][]float32, error) {
+	return e.vectors, nil
+}
+
+func TestValidateEmbeddedVectors(t *testing.T) {
+	tests := []struct {
+		name     string
+		vectors  [][]float32
+		expected int
+		wantErr  bool
+	}{
+		{"empty valid", [][]float32{}, 0, false},
+		{"correct count", fixedVectors(3, 64), 3, false},
+		{"wrong count", fixedVectors(2, 64), 3, true},
+		{"inconsistent dims", [][]float32{{1, 0}, {0, 1, 0}}, 2, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateEmbeddedVectors(tt.vectors, tt.expected)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("validateEmbeddedVectors() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestEmbedWithContext_UsesContextAwareEmbedder(t *testing.T) {
+	e := NewHashingEmbedder(64)
+	ctx := context.Background()
+
+	vecs, err := embedWithContext(ctx, e, []string{"test"})
+	if err != nil {
+		t.Fatalf("embedWithContext error: %v", err)
+	}
+	if len(vecs) != 1 {
+		t.Fatalf("expected 1 vector, got %d", len(vecs))
+	}
+}
+
+func TestEmbedWithContext_CanceledBeforeNonContextAware(t *testing.T) {
+	e := newDummyEmbedder(64) // doesn't implement contextAwareEmbedder
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := embedWithContext(ctx, e, []string{"test"})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context canceled, got %v", err)
+	}
+}

--- a/internal/engine/hashing.go
+++ b/internal/engine/hashing.go
@@ -1,6 +1,7 @@
 package engine
 
 import (
+	"context"
 	"hash/fnv"
 	"math"
 	"strings"
@@ -39,8 +40,24 @@ func NewHashingEmbedder(dim int) *HashingEmbedder {
 func (h *HashingEmbedder) Strategy() string { return "hashing" }
 
 func (h *HashingEmbedder) Embed(texts []string) ([][]float32, error) {
+	return h.EmbedContext(context.Background(), texts)
+}
+
+func (h *HashingEmbedder) EmbedContext(ctx context.Context, texts []string) ([][]float32, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
 	result := make([][]float32, len(texts))
 	for i, text := range texts {
+		if i%64 == 0 {
+			if err := ctx.Err(); err != nil {
+				return nil, err
+			}
+		}
 		result[i] = h.vectorize(text)
 	}
 	return result, nil

--- a/internal/engine/hashing_test.go
+++ b/internal/engine/hashing_test.go
@@ -1,6 +1,8 @@
 package engine
 
 import (
+	"context"
+	"errors"
 	"math"
 	"testing"
 )
@@ -254,6 +256,31 @@ func TestHashingEmbedder_BatchConsistency(t *testing.T) {
 				break
 			}
 		}
+	}
+}
+
+// Hardening tests
+
+func TestHashingEmbedder_EmbedContext_Canceled(t *testing.T) {
+	e := NewHashingEmbedder(128)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := e.EmbedContext(ctx, []string{"test"})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context canceled error, got %v", err)
+	}
+}
+
+func TestHashingEmbedder_EmbedContext_NilContext(t *testing.T) {
+	e := NewHashingEmbedder(128)
+	//nolint:staticcheck // intentionally testing nil context handling
+	vecs, err := e.EmbedContext(nil, []string{"test"})
+	if err != nil {
+		t.Fatalf("expected no error with nil context, got %v", err)
+	}
+	if len(vecs) != 1 || len(vecs[0]) != 128 {
+		t.Fatalf("expected 1 vector of dim 128, got %d vectors", len(vecs))
 	}
 }
 

--- a/internal/engine/lexical.go
+++ b/internal/engine/lexical.go
@@ -47,16 +47,25 @@ func NewLexicalMatcher() *LexicalMatcher {
 
 func (m *LexicalMatcher) Strategy() string { return "lexical" }
 
-func (m *LexicalMatcher) Find(_ context.Context, query string, elements []types.ElementDescriptor, opts types.FindOptions) (types.FindResult, error) {
-	ctx := ParseQueryContext(query)
-	return m.findWithParsed(ctx, elements, opts), nil
+func (m *LexicalMatcher) Find(ctx context.Context, query string, elements []types.ElementDescriptor, opts types.FindOptions) (types.FindResult, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return types.FindResult{}, err
+	}
+
+	queryCtx := ParseQueryContext(query)
+	return m.findWithParsedContext(ctx, queryCtx, elements, opts), nil
 }
 
-func (m *LexicalMatcher) findWithParsed(ctx QueryContext, elements []types.ElementDescriptor, opts types.FindOptions) types.FindResult {
-	parsed := ctx.Base
-	if opts.TopK <= 0 {
-		opts.TopK = 3
-	}
+func (m *LexicalMatcher) findWithParsed(queryCtx QueryContext, elements []types.ElementDescriptor, opts types.FindOptions) types.FindResult {
+	return m.findWithParsedContext(context.Background(), queryCtx, elements, opts)
+}
+
+func (m *LexicalMatcher) findWithParsedContext(ctx context.Context, queryCtx QueryContext, elements []types.ElementDescriptor, opts types.FindOptions) types.FindResult {
+	parsed := queryCtx.Base
+	opts = sanitizeFindOptions(opts, len(elements), 3)
 
 	if len(parsed.Positive) == 0 && len(parsed.Negative) == 0 {
 		return types.FindResult{
@@ -76,8 +85,14 @@ func (m *LexicalMatcher) findWithParsed(ctx QueryContext, elements []types.Eleme
 	}
 
 	var candidates []scored
-	for _, el := range elements {
-		if ctx.HasScope && matchesExcludedContext(el, ctx.Exclude) {
+	for i, el := range elements {
+		if i%64 == 0 {
+			if ctx.Err() != nil {
+				break
+			}
+		}
+
+		if queryCtx.HasScope && matchesExcludedContext(el, queryCtx.Exclude) {
 			continue
 		}
 
@@ -85,7 +100,6 @@ func (m *LexicalMatcher) findWithParsed(ctx QueryContext, elements []types.Eleme
 		descTokens := tokenize(composite)
 		score := 0.0
 		if len(parsed.Positive) == 0 {
-			// Negative-only query means "everything except negatives".
 			score = 1.0
 		} else {
 			score = lexicalScoreTokens(parsed.Positive, descTokens, el.Interactive, ef)
@@ -93,15 +107,11 @@ func (m *LexicalMatcher) findWithParsed(ctx QueryContext, elements []types.Eleme
 		}
 
 		if len(parsed.Negative) > 0 {
-			// Debug note: negativeScore reflects how strongly negative tokens match
-			// this element; hasStrongNegativeHit indicates exact/synonym token hit.
 			negativeScore := lexicalScoreTokens(parsed.Negative, descTokens, el.Interactive, ef)
 			switch {
 			case hasStrongNegativeHit(parsed.Negative, descTokens) || negativeScore > 0.7:
-				// Applied penalty: full exclusion.
 				score = 0
 			case negativeScore > 0.4:
-				// Applied penalty: multiplicative down-weight.
 				score *= 1 - negativeScore
 			}
 		}

--- a/internal/engine/lexical_test.go
+++ b/internal/engine/lexical_test.go
@@ -2,10 +2,12 @@ package engine
 
 import (
 	"context"
-	"github.com/pinchtab/semantic/internal/types"
+	"errors"
 	"math"
 	"strconv"
 	"testing"
+
+	"github.com/pinchtab/semantic/internal/types"
 )
 
 func TestTokenPrefixScore_BtnButton(t *testing.T) {
@@ -640,6 +642,22 @@ func TestLexicalMatcher_EmptyQueryReturnsNoResults(t *testing.T) {
 	}
 	if len(result.Matches) != 0 {
 		t.Fatalf("expected no matches for empty query, got %d", len(result.Matches))
+	}
+}
+
+// Hardening tests
+
+func TestLexicalMatcher_Find_ContextCanceled(t *testing.T) {
+	m := NewLexicalMatcher()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := m.Find(ctx, "submit button", []types.ElementDescriptor{
+		{Ref: "e1", Role: "button", Name: "Submit"},
+	}, types.FindOptions{Threshold: 0, TopK: 1})
+
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context canceled error, got %v", err)
 	}
 }
 

--- a/internal/engine/options.go
+++ b/internal/engine/options.go
@@ -1,0 +1,36 @@
+package engine
+
+import (
+	"math"
+
+	"github.com/pinchtab/semantic/internal/types"
+)
+
+func sanitizeFindOptions(opts types.FindOptions, elementCount int, defaultTopK int) types.FindOptions {
+	if defaultTopK <= 0 {
+		defaultTopK = 3
+	}
+
+	if opts.TopK <= 0 {
+		opts.TopK = defaultTopK
+	}
+	if elementCount >= 0 && opts.TopK > elementCount {
+		opts.TopK = elementCount
+	}
+
+	opts.Threshold = sanitizeThreshold(opts.Threshold)
+	return opts
+}
+
+func sanitizeThreshold(threshold float64) float64 {
+	if math.IsNaN(threshold) || math.IsInf(threshold, 0) {
+		return 0
+	}
+	if threshold < 0 {
+		return 0
+	}
+	if threshold > 1 {
+		return 1
+	}
+	return threshold
+}

--- a/internal/engine/testing_helpers_test.go
+++ b/internal/engine/testing_helpers_test.go
@@ -47,3 +47,16 @@ func (d *dummyEmbedder) hashVec(s string) []float32 {
 	}
 	return vec
 }
+
+func fixedVectors(n, dim int) [][]float32 {
+	if dim <= 0 {
+		dim = 1
+	}
+	vectors := make([][]float32, n)
+	for i := 0; i < n; i++ {
+		vec := make([]float32, dim)
+		vec[i%dim] = 1
+		vectors[i] = vec
+	}
+	return vectors
+}

--- a/tests/e2e/cases/16-input-hardening.sh
+++ b/tests/e2e/cases/16-input-hardening.sh
@@ -50,11 +50,16 @@ set -e
 assert_eq "$exit_code" "0" "hardening: weights > 1 don't crash"
 
 # Verify scores are still bounded [0,1] with extreme weights
-best_score=$(echo "$result" | jq '.best_score')
-if awk "BEGIN {exit !($best_score >= 0 && $best_score <= 1)}"; then
-  pass "hardening: scores bounded with extreme weights"
+if [ "$exit_code" != "0" ]; then
+  fail "hardening: scores bounded with extreme weights" "semantic find failed: $result"
+elif best_score=$(echo "$result" | jq -er '.best_score' 2>/dev/null); then
+  if awk "BEGIN {exit !($best_score >= 0 && $best_score <= 1)}"; then
+    pass "hardening: scores bounded with extreme weights"
+  else
+    fail "hardening: scores bounded with extreme weights" "got score $best_score"
+  fi
 else
-  fail "hardening: scores bounded with extreme weights" "got score $best_score"
+  fail "hardening: scores bounded with extreme weights" "semantic find returned invalid JSON: $result"
 fi
 
 summary "input-hardening"

--- a/tests/e2e/cases/16-input-hardening.sh
+++ b/tests/e2e/cases/16-input-hardening.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+CASE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${CASE_DIR}/../lib.sh"
+
+echo "  ── Find: Input Hardening / Edge Cases ──"
+
+SNAPSHOT="${ASSETS_DIR}/snapshots/login-page.json"
+
+# Negative threshold (should be clamped to 0)
+set +e
+result=$(semantic find "sign in" --snapshot "$SNAPSHOT" --format json --threshold -0.5 2>&1)
+exit_code=$?
+set -e
+assert_eq "$exit_code" "0" "hardening: negative threshold doesn't crash"
+
+# Threshold > 1 (should be clamped to 1, returning no matches)
+result=$(semantic find "sign in" --snapshot "$SNAPSHOT" --format json --threshold 1.5)
+count=$(echo "$result" | jq '.matches | length')
+assert_eq "$count" "0" "hardening: threshold > 1 returns no matches"
+
+# Zero topk (should use default)
+set +e
+result=$(semantic find "sign in" --snapshot "$SNAPSHOT" --format json --top-k 0 2>&1)
+exit_code=$?
+set -e
+assert_eq "$exit_code" "0" "hardening: zero topk doesn't crash"
+
+# Negative topk (should use default)
+set +e
+result=$(semantic find "sign in" --snapshot "$SNAPSHOT" --format json --top-k -5 2>&1)
+exit_code=$?
+set -e
+assert_eq "$exit_code" "0" "hardening: negative topk doesn't crash"
+
+# Very large topk (should be clamped to element count)
+result=$(semantic find "sign in" --snapshot "$SNAPSHOT" --format json --top-k 10000 --threshold 0)
+count=$(echo "$result" | jq '.matches | length')
+elem_count=$(jq 'length' "$SNAPSHOT")
+if [ "$count" -le "$elem_count" ]; then
+  pass "hardening: large topk clamped to element count"
+else
+  fail "hardening: large topk clamped to element count" "got $count matches, expected <= $elem_count"
+fi
+
+# Custom weights that sum to > 1
+set +e
+result=$(semantic find "sign in" --snapshot "$SNAPSHOT" --format json --lexical-weight 2 --embedding-weight 2 2>&1)
+exit_code=$?
+set -e
+assert_eq "$exit_code" "0" "hardening: weights > 1 don't crash"
+
+# Verify scores are still bounded [0,1] with extreme weights
+best_score=$(echo "$result" | jq '.best_score')
+if awk "BEGIN {exit !($best_score >= 0 && $best_score <= 1)}"; then
+  pass "hardening: scores bounded with extreme weights"
+else
+  fail "hardening: scores bounded with extreme weights" "got score $best_score"
+fi
+
+summary "input-hardening"

--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -11,6 +11,20 @@ else
   ASSETS_DIR="${E2E_DIR}/assets"
 fi
 
+if [ "$E2E_DIR" != "/e2e" ] && [ -z "${SEMANTIC_E2E_BOOTSTRAPPED:-}" ]; then
+  REPO_ROOT="$(cd "${E2E_DIR}/../.." && pwd)"
+  if ! command -v go >/dev/null 2>&1; then
+    echo "ERROR: go is required to run local E2E tests" >&2
+    exit 1
+  fi
+  if ! (cd "$REPO_ROOT" && go build -o "${E2E_DIR}/semantic" ./cmd/semantic); then
+    echo "ERROR: failed to build semantic binary for local E2E tests" >&2
+    exit 1
+  fi
+  export PATH="${E2E_DIR}:$PATH"
+  export SEMANTIC_E2E_BOOTSTRAPPED=1
+fi
+
 PASSED=0
 FAILED=0
 ERRORS=""

--- a/tests/e2e/run.sh
+++ b/tests/e2e/run.sh
@@ -7,6 +7,9 @@ echo "  semantic E2E tests"
 echo "═══════════════════════════════════════════════════"
 echo ""
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/lib.sh"
+
 # Verify binary is available
 if ! command -v semantic &>/dev/null; then
   echo "ERROR: semantic binary not found"
@@ -24,7 +27,6 @@ run_suite() {
 }
 
 # Run all test suites
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 for suite in "${SCRIPT_DIR}"/cases/*.sh; do
   [ -f "$suite" ] || continue
   echo ""


### PR DESCRIPTION
## Summary
Hardens matcher behavior around invalid or extreme inputs, and improves cancellation handling.

## What changed
- input sanitization and bounds handling across matcher flows
- context cancellation hardening
- added hardening-focused tests
- includes the currently stacked benchmark/visual/ranking work already present beneath this branch

## Validation
- `go test ./... -count=1`

## Notes
- This branch is stacked on top of the recent benchmark/visual work, so the diff is broader than the top commit alone.
- **Supersedes #32** with the same hardening direction carried forward on top of newer branch history.
